### PR TITLE
[all] Add support for sound streams

### DIFF
--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -201,13 +201,13 @@ dependencies = [
  "serde_derive 1.0.83 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "swf-fixed 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "swf-tree 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "swf-tree 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "test-generator 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "swf-tree"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -292,7 +292,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum serde_derive 1.0.83 (registry+https://github.com/rust-lang/crates.io-index)" = "9469829702497daf2daf3c190e130c3fa72f719920f73c86160d43e8f8d76951"
 "checksum serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)" = "c37ccd6be3ed1fdf419ee848f7c758eb31b054d7cd3ae3600e3bae0adf569811"
 "checksum swf-fixed 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a415efca192c4f4881d9e963d582e95c2c6f6be71cea59a42126068bedd1e0b1"
-"checksum swf-tree 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2503a6feeb2ef12a4e94ebe3542f76b5ae4f7e355bd7fc83246e65f4734961b6"
+"checksum swf-tree 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aa0ce102bbc627f495a54f0f90a3ac2639c606d8c722dc646681d48271d0e0fa"
 "checksum syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)" = "1825685f977249735d510a242a6727b46efe914bb67e38d30c071b1b72b1d5c2"
 "checksum test-generator 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9b26bb9ef026bbc1e5abab33e3299be7b31b73790c0980e225241d694ccd6f71"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -28,7 +28,7 @@ num-traits = "^0.2.6"
 regex = "^1.0.5"
 serde = "^1.0.80"
 serde_derive = "^1.0.80"
-swf-tree = "^0.2.1"
+swf-tree = "^0.3.0"
 swf-fixed = "^0.1.0"
 
 [dev-dependencies]

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -28,12 +28,12 @@ num-traits = "^0.2.6"
 regex = "^1.0.5"
 serde = "^1.0.80"
 serde_derive = "^1.0.80"
+serde_json = "^1.0.32"
 swf-tree = "^0.3.0"
 swf-fixed = "^0.1.0"
 
 [dev-dependencies]
 test-generator = "^0.2.2"
-serde_json = "^1.0.32"
 
 # [replace]
 # "swf-tree:0.0.18" = { path = '../../swf-tree/swf-tree.rs' }

--- a/rs/src/parsers/sound.rs
+++ b/rs/src/parsers/sound.rs
@@ -23,3 +23,12 @@ pub fn audio_coding_format_from_id(audio_coding_format_id: u8) -> ast::AudioCodi
     _ => panic!("Unexpected audio coding format id"),
   }
 }
+
+// TODO: Implement `Copy` on `AudioCodingFormat` and pass it by value
+pub fn is_uncompressed_audio_coding_format(format: &ast::AudioCodingFormat) -> bool {
+  match format {
+    ast::AudioCodingFormat::UncompressedNativeEndian => true,
+    ast::AudioCodingFormat::UncompressedLittleEndian => true,
+    _ => false,
+  }
+}

--- a/ts/package.json
+++ b/ts/package.json
@@ -27,7 +27,7 @@
     "@open-flash/stream": "^0.1.0",
     "incident": "^3.2.0",
     "semantic-types": "^0.1.1",
-    "swf-tree": "^0.2.1"
+    "swf-tree": "^0.3.0"
   },
   "devDependencies": {
     "@types/chai": "^4.1.7",

--- a/ts/src/lib/parsers/sound.ts
+++ b/ts/src/lib/parsers/sound.ts
@@ -40,3 +40,7 @@ export function getAudioCodingFormatFromCode(formatCode: Uint4): AudioCodingForm
       throw new Incident("UnexpectedFormatCode", {code: formatCode});
   }
 }
+
+export function isUncompressedAudioCodingFormat(format: AudioCodingFormat): boolean {
+  return format === AudioCodingFormat.UncompressedNativeEndian || format === AudioCodingFormat.UncompressedLittleEndian;
+}

--- a/ts/src/test/movie-from-bytes.spec.ts
+++ b/ts/src/test/movie-from-bytes.spec.ts
@@ -14,7 +14,7 @@ const JSON_READER: JsonReader = new JsonReader();
 const JSON_VALUE_WRITER: JsonValueWriter = new JsonValueWriter();
 
 describe.only("movieFromBytes", function () {
-  this.timeout(10000);
+  this.timeout(300000); // The timeout is this high due to CI being extremely slow
 
   for (const sample of getSamples()) {
     it(sample.name, async function () {

--- a/ts/src/test/movie-from-bytes.spec.ts
+++ b/ts/src/test/movie-from-bytes.spec.ts
@@ -3,10 +3,9 @@ import fs from "fs";
 import { JsonReader } from "kryo/readers/json";
 import { JsonValueWriter } from "kryo/writers/json-value";
 import sysPath from "path";
-import meta from "./meta.js";
+import { $Movie, Movie } from "swf-tree/movie";
 import { movieFromBytes } from "../lib";
-import { Movie } from "swf-tree";
-import { $Movie } from "swf-tree/movie";
+import meta from "./meta.js";
 
 const PROJECT_ROOT: string = sysPath.join(meta.dirname, "..", "..", "..");
 const TEST_SAMPLES_ROOT: string = sysPath.join(PROJECT_ROOT, "..", "tests", "open-flash-db", "standalone-movies");

--- a/ts/yarn.lock
+++ b/ts/yarn.lock
@@ -3871,10 +3871,10 @@ sver-compat@^1.5.0:
     es6-iterator "^2.0.1"
     es6-symbol "^3.1.1"
 
-swf-tree@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/swf-tree/-/swf-tree-0.2.1.tgz#58e351ee4dfb8c53c808333b4eac3a5fdb81b08b"
-  integrity sha512-R0LFaNXXgOrXRxOX4qaW5fxbl5JkHahY7iiDsNIYBokLHWXTxY9QFb6wrxWAUk/wINoK+kHlVnrAS8I9DIgO6g==
+swf-tree@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/swf-tree/-/swf-tree-0.3.0.tgz#8d912839b85efdc33d207fc064c1aa942798c1b8"
+  integrity sha512-LKokaLQ2iooBMC39dAXCp9qf7M+cAtU+pZhqJW1XAZxzcSLYpVlRJwUbGNLY+W7tTwcdpRn7WEyaImjyAqKF3A==
   dependencies:
     incident "^3.2.0"
     kryo "^0.8.1"


### PR DESCRIPTION
Update to `swf-tree@0.3.0` (refactored sound tags) and implement sound stream parsers.