### PR TITLE
[all] Implement parsers to support `homestuck-02971`

### DIFF
--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -172,7 +172,7 @@ dependencies = [
 
 [[package]]
 name = "swf-fixed"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -188,23 +188,21 @@ dependencies = [
  "nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "swf-fixed 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "swf-tree 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "swf-fixed 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "swf-tree 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "test-generator 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "swf-tree"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "swf-fixed 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "swf-fixed 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -281,8 +279,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)" = "92514fb95f900c9b5126e32d020f5c6d40564c27a5ea6d1d7d9f157a96623560"
 "checksum serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)" = "bb6eabf4b5914e88e24eea240bb7c9f9a2cbc1bbbe8d961d381975ec3c6b806c"
 "checksum serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)" = "5a23aa71d4a4d43fdbfaac00eff68ba8a06a51759a89ac3304323e800c4dd40d"
-"checksum swf-fixed 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a415efca192c4f4881d9e963d582e95c2c6f6be71cea59a42126068bedd1e0b1"
-"checksum swf-tree 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aa0ce102bbc627f495a54f0f90a3ac2639c606d8c722dc646681d48271d0e0fa"
+"checksum swf-fixed 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f58f3f8a3cb887fcf22d47590ce187e4541729700a9cc24ad582fc54d240f911"
+"checksum swf-tree 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0e8dabe97879fbff4fdc74c34f78ad0ddc2c42a1bf479381c6758844732e1fd3"
 "checksum syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)" = "1825685f977249735d510a242a6727b46efe914bb67e38d30c071b1b72b1d5c2"
 "checksum test-generator 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9b26bb9ef026bbc1e5abab33e3299be7b31b73790c0980e225241d694ccd6f71"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -26,14 +26,12 @@ lzma-rs = "^0.1.1"
 nom = "^4.2.2"
 num-traits = "^0.2.6"
 regex = "^1.0.5"
-serde = "^1.0.80"
-serde_derive = "^1.0.80"
-serde_json = "^1.0.32"
-swf-tree = "^0.3.0"
-swf-fixed = "^0.1.0"
+serde_json = "^1.0.39"
+swf-tree = "^0.4.1"
+swf-fixed = "^0.1.1"
 
 [dev-dependencies]
 test-generator = "^0.2.2"
 
 # [replace]
-# "swf-tree:0.0.18" = { path = '../../swf-tree/swf-tree.rs' }
+# "swf-tree:0.4.1" = { path = '../../swf-tree/rs' }

--- a/rs/README.md
+++ b/rs/README.md
@@ -5,7 +5,6 @@
 
 # SWF Parser
 
-[![npm](https://img.shields.io/npm/v/swf-parser.svg?maxAge=2592000)](https://www.npmjs.com/package/swf-parser)
 [![crates.io](https://img.shields.io/crates/v/swf-parser.svg?maxAge=2592000)](https://crates.io/crates/swf-parser)
 [![GitHub repository](https://img.shields.io/badge/Github-open--flash%2Fswf--parser-blue.svg)](https://github.com/open-flash/swf-parser)
 [![Build status](https://img.shields.io/travis/open-flash/swf-parser/master.svg?maxAge=2592000)](https://travis-ci.org/open-flash/swf-parser)

--- a/rs/src/lib.rs
+++ b/rs/src/lib.rs
@@ -2,8 +2,6 @@ extern crate inflate;
 #[macro_use]
 extern crate nom;
 extern crate num_traits;
-extern crate serde;
-extern crate serde_derive;
 extern crate swf_fixed;
 extern crate swf_tree;
 

--- a/ts/package.json
+++ b/ts/package.json
@@ -27,7 +27,7 @@
     "@open-flash/stream": "^0.1.0",
     "incident": "^3.2.0",
     "semantic-types": "^0.1.1",
-    "swf-tree": "^0.3.0"
+    "swf-tree": "^0.4.0"
   },
   "devDependencies": {
     "@types/chai": "^4.1.7",

--- a/ts/src/lib/parsers/sound.ts
+++ b/ts/src/lib/parsers/sound.ts
@@ -1,6 +1,9 @@
+import { ReadableByteStream } from "@open-flash/stream";
 import { Incident } from "incident";
-import { Uint2, Uint4 } from "semantic-types";
+import { Uint16, Uint2, Uint32, Uint4, Uint8, UintSize } from "semantic-types";
 import { AudioCodingFormat } from "swf-tree/sound/audio-coding-format";
+import { SoundEnvelope } from "swf-tree/sound/sound-envelope";
+import { SoundInfo } from "swf-tree/sound/sound-info";
 import { SoundRate } from "swf-tree/sound/sound-rate";
 
 export function getSoundRateFromCode(soundRateCode: Uint2): SoundRate {
@@ -43,4 +46,37 @@ export function getAudioCodingFormatFromCode(formatCode: Uint4): AudioCodingForm
 
 export function isUncompressedAudioCodingFormat(format: AudioCodingFormat): boolean {
   return format === AudioCodingFormat.UncompressedNativeEndian || format === AudioCodingFormat.UncompressedLittleEndian;
+}
+
+export function parseSoundInfo(byteStream: ReadableByteStream): SoundInfo {
+  const flags: Uint8 = byteStream.readUint8();
+
+  const hasInPoint: boolean = (flags & (1 << 0)) !== 0;
+  const hasOutPoint: boolean = (flags & (1 << 1)) !== 0;
+  const hasLoops: boolean = (flags & (1 << 2)) !== 0;
+  const hasEnvelope: boolean = (flags & (1 << 3)) !== 0;
+  const syncNoMultiple: boolean = (flags & (1 << 4)) !== 0;
+  const syncStop: boolean = (flags & (1 << 6)) !== 0;
+  // Bits [6, 7] are reserved
+
+  const inPoint: Uint32 | undefined = hasInPoint ? byteStream.readUint32LE() : undefined;
+  const outPoint: Uint32 | undefined = hasOutPoint ? byteStream.readUint32LE() : undefined;
+  const loopCount: Uint16 | undefined = hasLoops ? byteStream.readUint16LE() : undefined;
+  let envelopeRecords: SoundEnvelope[] | undefined;
+  if (hasEnvelope) {
+    envelopeRecords = [];
+    const recordCount: UintSize = byteStream.readUint8();
+    for (let i: UintSize = 0; i < recordCount; i++) {
+      envelopeRecords.push(parseSoundEnvelope(byteStream));
+    }
+  }
+
+  return {syncStop, syncNoMultiple, inPoint, outPoint, loopCount, envelopeRecords};
+}
+
+export function parseSoundEnvelope(byteStream: ReadableByteStream): SoundEnvelope {
+  const pos44: Uint32 = byteStream.readUint32LE();
+  const leftLevel: Uint16 = byteStream.readUint16LE();
+  const rightLevel: Uint16 = byteStream.readUint16LE();
+  return {pos44, leftLevel, rightLevel};
 }

--- a/ts/yarn.lock
+++ b/ts/yarn.lock
@@ -321,9 +321,9 @@
   integrity sha512-1axi39YdtBI7z957vdqXI4Ac25e7YihYQtJa+Clnxg1zTJEaIRbndt71O3sP4GAMgiAm0pY26/b9BrY4MR/PMw==
 
 "@types/node@*":
-  version "11.12.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-11.12.0.tgz#ec5594728811dc2797e42396cfcdf786f2052c12"
-  integrity sha512-Lg00egj78gM+4aE0Erw05cuDbvX9sLJbaaPwwRtdCdAMnIudqrQZ0oZX98Ek0yiSK/A2nubHgJfvII/rTT2Dwg==
+  version "11.12.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-11.12.1.tgz#d90123f6c61fdf2f7cddd286ddae891586dd3488"
+  integrity sha512-sKDlqv6COJrR7ar0+GqqhrXQDzQlMcqMnF2iEU6m9hLo8kxozoAGUazwPyELHlRVmjsbvlnGXjnzyptSXVmceA==
 
 "@types/node@^10.12.18":
   version "10.14.4"
@@ -3871,10 +3871,10 @@ sver-compat@^1.5.0:
     es6-iterator "^2.0.1"
     es6-symbol "^3.1.1"
 
-swf-tree@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/swf-tree/-/swf-tree-0.3.0.tgz#8d912839b85efdc33d207fc064c1aa942798c1b8"
-  integrity sha512-LKokaLQ2iooBMC39dAXCp9qf7M+cAtU+pZhqJW1XAZxzcSLYpVlRJwUbGNLY+W7tTwcdpRn7WEyaImjyAqKF3A==
+swf-tree@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/swf-tree/-/swf-tree-0.4.0.tgz#417b5cc5d9b926eea354caa7ed623ed815f6c171"
+  integrity sha512-cXLEUnQQKGCnhezbFW2MjUlIQL2rud+40sdjXYoP/3YPRgIK5wdKSHE7yEgEa6G1s0Xr1lMsu6y5U4ss4LAIkg==
   dependencies:
     incident "^3.2.0"
     kryo "^0.8.1"
@@ -4160,9 +4160,9 @@ typescript@3.1.x:
   integrity sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==
 
 typescript@^3.2.1, typescript@^3.2.4:
-  version "3.3.4000"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.3.4000.tgz#76b0f89cfdbf97827e1112d64f283f1151d6adf0"
-  integrity sha512-jjOcCZvpkl2+z7JFn0yBOoLQyLoIkNZAs/fYJkUG6VKy6zLPHJGfQJYFHzibB6GJaF/8QrcECtlQ5cpvRHSMEA==
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.1.tgz#b6691be11a881ffa9a05765a205cb7383f3b63c6"
+  integrity sha512-3NSMb2VzDQm8oBTLH6Nj55VVtUEpe/rgkIzMir0qVoLyjDZlnMBva0U6vDiV3IH+sl/Yu6oP5QwsAQtHPmDd2Q==
 
 uglify-js@^3.1.4:
   version "3.5.2"


### PR DESCRIPTION
Update to `swf-tree@0.4.x` and implement parsers for the following tags: `StartSound`, `ScriptLimits`, `SymbolClass`, `DoAbc`, `StartSound2`.