### PR TITLE
[all] Fix support for DefineButton2 with multiple ButtonCondAction

### DIFF
--- a/rs/src/parsers/button.rs
+++ b/rs/src/parsers/button.rs
@@ -82,8 +82,17 @@ pub fn parse_button2_cond_action_string(input: &[u8]) -> NomResult<&[u8], Vec<as
   let mut current_input: &[u8] = input;
   loop {
     let (input, next_action_offset) = parse_le_u16(current_input)?;
+
+    let (input, next_input) = if next_action_offset == 0 {
+      (input, &[] as &[u8])
+    } else {
+      let next_action_offset = next_action_offset as usize;
+      let le_u16_size = current_input.len() - input.len();
+      (&current_input[le_u16_size..next_action_offset], &current_input[next_action_offset..])
+    };
+
     match parse_button2_cond_action(input) {
-      Ok((next_input, cond_action)) => {
+      Ok((_, cond_action)) => {
         current_input = next_input;
         result.push(cond_action);
       }

--- a/ts/src/lib/parsers/button.ts
+++ b/ts/src/lib/parsers/button.ts
@@ -1,6 +1,6 @@
 import { ReadableByteStream } from "@open-flash/stream";
 import { Incident } from "incident";
-import { Uint16, Uint7, Uint8 } from "semantic-types";
+import { Uint16, Uint7, Uint8, UintSize } from "semantic-types";
 import { BlendMode } from "swf-tree/blend-mode";
 import { ButtonCond } from "swf-tree/button/button-cond";
 import { ButtonCondAction } from "swf-tree/button/button-cond-action";
@@ -82,8 +82,16 @@ export function parseButton2CondActionString(byteStream: ReadableByteStream): Bu
 
   let nextActionOffset: Uint16;
   do {
+    const pos: UintSize = byteStream.bytePos;
     nextActionOffset = byteStream.readUint16LE();
-    result.push(parseButton2CondAction(byteStream));
+    let condActionStream: ReadableByteStream;
+    if (nextActionOffset === 0) {
+      condActionStream = byteStream;
+    } else {
+      const condActionSize: UintSize = pos + nextActionOffset - byteStream.bytePos;
+      condActionStream = byteStream.take(condActionSize);
+    }
+    result.push(parseButton2CondAction(condActionStream));
   } while (nextActionOffset !== 0);
 
   return result;

--- a/ts/src/lib/parsers/tags.ts
+++ b/ts/src/lib/parsers/tags.ts
@@ -349,10 +349,19 @@ export function parseDefineButton2(byteStream: ReadableByteStream): tags.DefineB
   const flags: Uint8 = byteStream.readUint8();
   const trackAsMenu: boolean = (flags & (1 << 0)) !== 0;
   // Skip bits [1, 7]
-  // TODO: Assert action offset matches
+  const pos: UintSize = byteStream.bytePos;
   const actionOffset: Uint16 = byteStream.readUint16LE();
   const characters: ButtonRecord[] = parseButtonRecordString(byteStream, ButtonVersion.Button2);
-  const actions: ButtonCondAction[] = actionOffset === 0 ? [] : parseButton2CondActionString(byteStream);
+  let actions: ButtonCondAction[];
+  if (actionOffset === 0) {
+    actions = [];
+  } else {
+    const actionPos: UintSize = pos + actionOffset;
+    if (byteStream.bytePos !== actionPos) {
+      throw new Error("Bytestream position does not match DefineButton2 action position");
+    }
+    actions = parseButton2CondActionString(byteStream);
+  }
   return {type: TagType.DefineButton, id, trackAsMenu, characters, actions};
 }
 

--- a/ts/src/test/movie-from-bytes.spec.ts
+++ b/ts/src/test/movie-from-bytes.spec.ts
@@ -13,7 +13,7 @@ const TEST_SAMPLES_ROOT: string = sysPath.join(PROJECT_ROOT, "..", "tests", "ope
 const JSON_READER: JsonReader = new JsonReader();
 const JSON_VALUE_WRITER: JsonValueWriter = new JsonValueWriter();
 
-describe.only("movieFromBytes", function () {
+describe("movieFromBytes", function () {
   this.timeout(300000); // The timeout is this high due to CI being extremely slow
 
   for (const sample of getSamples()) {
@@ -87,6 +87,7 @@ interface Sample {
 function* getSamples(): IterableIterator<Sample> {
   yield {name: "blank"};
   yield {name: "hello-world"};
+  yield {name: "homestuck-00031"};
   yield {name: "homestuck-02791"};
   // yield {name: "homestuck-beta-1"};
   yield {name: "morph-rotating-square"};


### PR DESCRIPTION
The parser failed to use action offsets to consume individual `ButtonCondAction`, instead it consumed the whole input and then tried to read the next `ButtonCondAction`.

Reported by @eddyb in https://github.com/open-flash/swf-parser/pull/5#issuecomment-479183906