### PR TITLE
[Fix] Fix `ButtonCond` parser

### DIFF
--- a/rs/src/parsers/button.rs
+++ b/rs/src/parsers/button.rs
@@ -127,16 +127,16 @@ pub fn parse_button_cond(input: &[u8]) -> NomResult<&[u8], ast::ButtonCond> {
   do_parse!(
     input,
     flags: parse_le_u16 >>
-    key_press: map!(value!((flags >> 0) & 0x7f), key_press_from_id) >>
-    over_down_to_idle: value!((flags & (1 << 7)) != 0) >>
-    idle_to_over_up: value!((flags & (1 << 8)) != 0) >>
-    over_up_to_idle: value!((flags & (1 << 9)) != 0) >>
-    over_up_to_over_down: value!((flags & (1 << 10)) != 0) >>
-    over_down_to_over_up: value!((flags & (1 << 11)) != 0) >>
-    over_down_to_out_down: value!((flags & (1 << 12)) != 0) >>
-    out_down_to_over_down: value!((flags & (1 << 13)) != 0) >>
-    out_down_to_idle: value!((flags & (1 << 14)) != 0) >>
-    idle_to_over_down: value!((flags & (1 << 15)) != 0) >>
+    idle_to_over_up: value!((flags & (1 << 0)) != 0) >>
+    over_up_to_idle: value!((flags & (1 << 1)) != 0) >>
+    over_up_to_over_down: value!((flags & (1 << 2)) != 0) >>
+    over_down_to_over_up: value!((flags & (1 << 3)) != 0) >>
+    over_down_to_out_down: value!((flags & (1 << 4)) != 0) >>
+    out_down_to_over_down: value!((flags & (1 << 5)) != 0) >>
+    out_down_to_idle: value!((flags & (1 << 6)) != 0) >>
+    idle_to_over_down: value!((flags & (1 << 7)) != 0) >>
+    over_down_to_idle: value!((flags & (1 << 8)) != 0) >>
+    key_press: map!(value!((flags >> 9) & 0x7f), key_press_from_id) >>
     (ast::ButtonCond {
       key_press,
       over_down_to_idle,

--- a/ts/src/lib/parsers/button.ts
+++ b/ts/src/lib/parsers/button.ts
@@ -106,7 +106,16 @@ export function parseButton2CondAction(byteStream: ReadableByteStream): ButtonCo
 export function parseButtonCond(byteStream: ReadableByteStream): ButtonCond {
   const flags: Uint16 = byteStream.readUint16LE();
 
-  let keyPress: Uint7 | undefined = (flags >> 0) & 0x7f;
+  const idleToOverUp: boolean = (flags & (1 << 0)) !== 0;
+  const overUpToIdle: boolean = (flags & (1 << 1)) !== 0;
+  const overUpToOverDown: boolean = (flags & (1 << 2)) !== 0;
+  const overDownToOverUp: boolean = (flags & (1 << 3)) !== 0;
+  const overDownToOutDown: boolean = (flags & (1 << 4)) !== 0;
+  const outDownToOverDown: boolean = (flags & (1 << 5)) !== 0;
+  const outDownToIdle: boolean = (flags & (1 << 6)) !== 0;
+  const idleToOverDown: boolean = (flags & (1 << 7)) !== 0;
+  const overDownToIdle: boolean = (flags & (1 << 8)) !== 0;
+  let keyPress: Uint7 | undefined = (flags >> 9) & 0x7f;
   if (keyPress === 0) {
     keyPress = undefined;
   } else if (!(
@@ -117,16 +126,6 @@ export function parseButtonCond(byteStream: ReadableByteStream): ButtonCond {
   )) {
     throw new Incident("InvalidKeyCode", {code: keyPress});
   }
-
-  const overDownToIdle: boolean = (flags & (1 << 7)) !== 0;
-  const idleToOverUp: boolean = (flags & (1 << 8)) !== 0;
-  const overUpToIdle: boolean = (flags & (1 << 9)) !== 0;
-  const overUpToOverDown: boolean = (flags & (1 << 10)) !== 0;
-  const overDownToOverUp: boolean = (flags & (1 << 11)) !== 0;
-  const overDownToOutDown: boolean = (flags & (1 << 12)) !== 0;
-  const outDownToOverDown: boolean = (flags & (1 << 13)) !== 0;
-  const outDownToIdle: boolean = (flags & (1 << 14)) !== 0;
-  const idleToOverDown: boolean = (flags & (1 << 15)) !== 0;
 
   return {
     keyPress,


### PR DESCRIPTION
The parser was parsing the `ButtonCond` flags in the wrong order.
Reported and solved by @eddyb.

See: https://github.com/open-flash/swf-parser/pull/14#issuecomment-480501640