### PR TITLE
[all] Add placeholders for missing implementations

### DIFF
--- a/rs/src/parsers/tags.rs
+++ b/rs/src/parsers/tags.rs
@@ -65,21 +65,27 @@ pub fn parse_swf_tag<'a>(input: &'a [u8], state: &mut ParseState) -> IResult<&'a
           4 => map!(record_data, parse_place_object, |t| ast::Tag::PlaceObject(t)),
           5 => map!(record_data, parse_remove_object, |t| ast::Tag::RemoveObject(t)),
           6 => map!(record_data, apply!(parse_define_bits, state.get_swf_version()), |t| ast::Tag::DefineBitmap(t)),
+          7 => map!(record_data, parse_define_button, |t| ast::Tag::DefineButton(t)),
           8 => map!(record_data, apply!(parse_define_jpeg_tables, state.get_swf_version()), |t| ast::Tag::DefineJpegTables(t)),
           9 => map!(record_data, parse_set_background_color_tag, |t| ast::Tag::SetBackgroundColor(t)),
+          10 => map!(record_data, parse_define_font, |t| ast::Tag::DefineFont(t)),
           11 => map!(record_data, parse_define_text, |t| ast::Tag::DefineText(t)),
-          // TODO: Ignore DoAction if version >= 9 && use_as3
           12 => map!(record_data, parse_do_action, |t| ast::Tag::DoAction(t)),
+          13 => map!(record_data, parse_define_font_info, |t| ast::Tag::DefineFontInfo(t)),
           14 => map!(record_data, parse_define_sound, |t| ast::Tag::DefineSound(t)),
           15 => map!(record_data, parse_start_sound, |t| ast::Tag::StartSound(t)),
+          17 => map!(record_data, parse_define_button_sound, |_t| unimplemented!()),
           18 => map!(record_data, parse_sound_stream_head, |t| ast::Tag::SoundStreamHead(t)),
           19 => map!(record_data, parse_sound_stream_block, |t| ast::Tag::SoundStreamBlock(t)),
           20 => map!(record_data, parse_define_bits_lossless, |t| ast::Tag::DefineBitmap(t)),
           21 => map!(record_data, apply!(parse_define_bits_jpeg2, state.get_swf_version()), |t| ast::Tag::DefineBitmap(t)),
           22 => map!(record_data, parse_define_shape2, |t| ast::Tag::DefineShape(t)),
+          23 => map!(record_data, parse_define_button_cxform, |_t| unimplemented!()),
+          24 => map!(record_data, parse_protect, |_t| unimplemented!()),
           26 => map!(record_data, apply!(parse_place_object2, state.get_swf_version() >= 6), |t| ast::Tag::PlaceObject(t)),
           28 => map!(record_data, parse_remove_object2, |t| ast::Tag::RemoveObject(t)),
           32 => map!(record_data, parse_define_shape3, |t| ast::Tag::DefineShape(t)),
+          33 => map!(record_data, parse_define_text2, |t| ast::Tag::DefineText(t)),
           34 => map!(record_data, parse_define_button2, |t| ast::Tag::DefineButton(t)),
           35 => map!(record_data, apply!(parse_define_bits_jpeg3, state.get_swf_version()), |t| ast::Tag::DefineBitmap(t)),
           36 => map!(record_data, parse_define_bits_lossless2, |t| ast::Tag::DefineBitmap(t)),
@@ -88,10 +94,17 @@ pub fn parse_swf_tag<'a>(input: &'a [u8], state: &mut ParseState) -> IResult<&'a
           43 => map!(record_data, parse_frame_label, |t| ast::Tag::FrameLabel(t)),
           45 => map!(record_data, parse_sound_stream_head2, |t| ast::Tag::SoundStreamHead(t)),
           46 => map!(record_data, parse_define_morph_shape, |t| ast::Tag::DefineMorphShape(t)),
+          48 => map!(record_data, parse_define_font2, |t| ast::Tag::DefineFont(t)),
           56 => map!(record_data, parse_export_assets, |t| ast::Tag::ExportAssets(t)),
           57 => map!(record_data, parse_import_assets, |t| ast::Tag::ImportAssets(t)),
+          58 => map!(record_data, parse_enable_debugger, |t| ast::Tag::EnableDebugger(t)),
           59 => map!(record_data, parse_do_init_action, |t| ast::Tag::DoInitAction(t)),
+          60 => map!(record_data, parse_define_video_stream, |_t| unimplemented!()),
+          61 => map!(record_data, parse_video_frame, |_t| unimplemented!()),
+          62 => map!(record_data, parse_define_font_info2, |t| ast::Tag::DefineFontInfo(t)),
+          64 => map!(record_data, parse_enable_debugger2, |t| ast::Tag::EnableDebugger(t)),
           65 => map!(record_data, parse_script_limits, |t| ast::Tag::ScriptLimits(t)),
+          66 => map!(record_data, parse_set_tab_index, |_t| unimplemented!()),
           69 => map!(record_data, parse_file_attributes_tag, |t| ast::Tag::FileAttributes(t)),
           70 => map!(record_data, apply!(parse_place_object3, state.get_swf_version() >= 6), |t| ast::Tag::PlaceObject(t)),
           71 => map!(record_data, parse_import_assets2, |t| ast::Tag::ImportAssets(t)),
@@ -100,12 +113,17 @@ pub fn parse_swf_tag<'a>(input: &'a [u8], state: &mut ParseState) -> IResult<&'a
           75 => map!(record_data, parse_define_font3, |t| ast::Tag::DefineFont(t)),
           76 => map!(record_data, parse_symbol_class, |t| ast::Tag::SymbolClass(t)),
           77 => map!(record_data, parse_metadata, |t| ast::Tag::Metadata(t)),
+          78 => map!(record_data, parse_define_scaling_grid, |_t| unimplemented!()),
           82 => map!(record_data, parse_do_abc, |t| ast::Tag::DoAbc(t)),
           83 => map!(record_data, parse_define_shape4, |t| ast::Tag::DefineShape(t)),
           84 => map!(record_data, parse_define_morph_shape2, |t| ast::Tag::DefineMorphShape(t)),
           86 => map!(record_data, parse_define_scene_and_frame_label_data_tag, |t| ast::Tag::DefineSceneAndFrameLabelData(t)),
+          87 => map!(record_data, parse_define_binary_data, |t| ast::Tag::DefineBinaryData(t)),
           88 => map!(record_data, parse_define_font_name, |t| ast::Tag::DefineFontName(t)),
           89 => map!(record_data, parse_start_sound2, |t| ast::Tag::StartSound2(t)),
+          90 => map!(record_data, parse_define_bits_jpeg4, |t| ast::Tag::DefineBitmap(t)),
+          91 => map!(record_data, parse_define_font4, |t| ast::Tag::DefineFont(t)),
+          93 => map!(record_data, parse_enable_telemetry, |_t| unimplemented!()),
           _ => {
             Ok((&[][..], ast::Tag::Unknown(ast::tags::Unknown { code: rh.tag_code, data: record_data.to_vec() })))
           }
@@ -154,6 +172,10 @@ pub fn parse_csm_text_settings(input: &[u8]) -> IResult<&[u8], ast::tags::CsmTex
   )
 }
 
+pub fn parse_define_binary_data(_input: &[u8]) -> IResult<&[u8], ast::tags::DefineBinaryData> {
+  unimplemented!()
+}
+
 pub fn parse_define_bits(input: &[u8], swf_version: u8) -> IResult<&[u8], ast::tags::DefineBitmap> {
   let (input, id) = parse_le_u16(input)?;
   let data: Vec<u8> = input.to_vec();
@@ -172,6 +194,10 @@ pub fn parse_define_bits(input: &[u8], swf_version: u8) -> IResult<&[u8], ast::t
   } else {
     panic!("UnknownBitmapType");
   }
+}
+
+pub fn parse_define_button(_input: &[u8]) -> IResult<&[u8], ast::tags::DefineButton> {
+  unimplemented!()
 }
 
 pub fn parse_define_button2(input: &[u8]) -> IResult<&[u8], ast::tags::DefineButton> {
@@ -195,6 +221,14 @@ pub fn parse_define_button2(input: &[u8]) -> IResult<&[u8], ast::tags::DefineBut
       actions,
     })
   )
+}
+
+pub fn parse_define_button_cxform(_input: &[u8]) -> IResult<&[u8], ()> {
+  unimplemented!()
+}
+
+pub fn parse_define_button_sound(_input: &[u8]) -> IResult<&[u8], ()> {
+  unimplemented!()
 }
 
 pub fn parse_define_bits_jpeg2(input: &[u8], swf_version: u8) -> IResult<&[u8], ast::tags::DefineBitmap> {
@@ -251,6 +285,10 @@ pub fn parse_define_bits_jpeg3(input: &[u8], swf_version: u8) -> IResult<&[u8], 
     media_type,
     data,
   }))
+}
+
+pub fn parse_define_bits_jpeg4(_input: &[u8]) -> IResult<&[u8], ast::tags::DefineBitmap> {
+  unimplemented!()
 }
 
 pub fn parse_define_bits_lossless(input: &[u8]) -> IResult<&[u8], ast::tags::DefineBitmap> {
@@ -345,6 +383,14 @@ pub fn parse_define_edit_text(input: &[u8]) -> IResult<&[u8], ast::tags::DefineD
   )
 }
 
+pub fn parse_define_font(_input: &[u8]) -> IResult<&[u8], ast::tags::DefineFont> {
+  unimplemented!()
+}
+
+pub fn parse_define_font2(_input: &[u8]) -> IResult<&[u8], ast::tags::DefineFont> {
+  unimplemented!()
+}
+
 // https://github.com/mozilla/shumway/blob/16451d8836fa85f4b16eeda8b4bda2fa9e2b22b0/src/swf/parser/module.ts#L632
 pub fn parse_define_font3(input: &[u8]) -> IResult<&[u8], ast::tags::DefineFont> {
   do_parse!(
@@ -397,6 +443,10 @@ pub fn parse_define_font3(input: &[u8]) -> IResult<&[u8], ast::tags::DefineFont>
   )
 }
 
+pub fn parse_define_font4(_input: &[u8]) -> IResult<&[u8], ast::tags::DefineFont> {
+  unimplemented!()
+}
+
 pub fn parse_define_font_align_zones<P>(input: &[u8], glyph_count_provider: P) -> IResult<&[u8], ast::tags::DefineFontAlignZones>
   where P: Fn(usize) -> Option<usize> {
   do_parse!(
@@ -412,6 +462,14 @@ pub fn parse_define_font_align_zones<P>(input: &[u8], glyph_count_provider: P) -
       zones: zones,
     })
   )
+}
+
+pub fn parse_define_font_info(_input: &[u8]) -> IResult<&[u8], ast::tags::DefineFontInfo> {
+  unimplemented!()
+}
+
+pub fn parse_define_font_info2(_input: &[u8]) -> IResult<&[u8], ast::tags::DefineFontInfo> {
+  unimplemented!()
 }
 
 pub fn parse_define_font_name(input: &[u8]) -> IResult<&[u8], ast::tags::DefineFontName> {
@@ -476,6 +534,9 @@ fn parse_define_morph_shape_any(input: &[u8], version: MorphShapeVersion) -> IRe
   )
 }
 
+pub fn parse_define_scaling_grid(_input: &[u8]) -> IResult<&[u8], ()> {
+  unimplemented!()
+}
 
 pub fn parse_define_scene_and_frame_label_data_tag(input: &[u8]) -> IResult<&[u8], ast::tags::DefineSceneAndFrameLabelData> {
   do_parse!(
@@ -618,6 +679,14 @@ pub fn parse_define_text(input: &[u8]) -> IResult<&[u8], ast::tags::DefineText> 
   )
 }
 
+pub fn parse_define_text2(_input: &[u8]) -> IResult<&[u8], ast::tags::DefineText> {
+  unimplemented!()
+}
+
+pub fn parse_define_video_stream(_input: &[u8]) -> IResult<&[u8], ()> {
+  unimplemented!()
+}
+
 pub fn parse_do_abc(input: &[u8]) -> IResult<&[u8], ast::tags::DoAbc> {
   let (input, flags) = parse_le_u32(input)?;
   let (input, name) = parse_c_string(input)?;
@@ -635,6 +704,18 @@ pub fn parse_do_init_action(input: &[u8]) -> IResult<&[u8], ast::tags::DoInitAct
   let (input, actions) = (&[][..], input.to_vec());
   let tag = ast::tags::DoInitAction { sprite_id, actions };
   Ok((input, tag))
+}
+
+pub fn parse_enable_debugger(_input: &[u8]) -> IResult<&[u8], ast::tags::EnableDebugger> {
+  unimplemented!()
+}
+
+pub fn parse_enable_debugger2(_input: &[u8]) -> IResult<&[u8], ast::tags::EnableDebugger> {
+  unimplemented!()
+}
+
+pub fn parse_enable_telemetry(_input: &[u8]) -> IResult<&[u8], ()> {
+  unimplemented!()
 }
 
 pub fn parse_export_assets(input: &[u8]) -> IResult<&[u8], ast::tags::ExportAssets> {
@@ -867,6 +948,10 @@ pub fn parse_place_object3(input: &[u8], extended_events: bool) -> IResult<&[u8]
   )
 }
 
+pub fn parse_protect(_input: &[u8]) -> IResult<&[u8], ()> {
+  unimplemented!()
+}
+
 pub fn parse_remove_object(input: &[u8]) -> IResult<&[u8], ast::tags::RemoveObject> {
   do_parse!(
     input,
@@ -910,6 +995,10 @@ pub fn parse_set_background_color_tag(input: &[u8]) -> IResult<&[u8], ast::tags:
       color: color,
     })
   )
+}
+
+pub fn parse_set_tab_index(_input: &[u8]) -> IResult<&[u8], ()> {
+  unimplemented!()
 }
 
 fn parse_sound_stream_block(input: &[u8]) -> IResult<&[u8], ast::tags::SoundStreamBlock> {
@@ -1002,4 +1091,8 @@ pub fn parse_symbol_class(input: &[u8]) -> IResult<&[u8], ast::tags::SymbolClass
       symbols,
     })
   )
+}
+
+pub fn parse_video_frame(_input: &[u8]) -> IResult<&[u8], ()> {
+  unimplemented!()
 }

--- a/ts/src/lib/parsers/tags.ts
+++ b/ts/src/lib/parsers/tags.ts
@@ -145,19 +145,26 @@ function parseTagBody(byteStream: ReadableByteStream, tagCode: Uint8, context: P
       return parseRemoveObject(byteStream);
     case 6:
       return parseDefineBits(byteStream, context.getVersion());
+    case 7:
+      return parseDefineButton(byteStream);
     case 8:
       return parseDefineJpegTables(byteStream, context.getVersion());
     case 9:
       return parseSetBackgroundColor(byteStream);
+    case 10:
+      return parseDefineFont(byteStream);
     case 11:
       return parseDefineText(byteStream);
     case 12:
-      // TODO: Ignore DoAction if version >= 9 && use_as3
       return parseDoAction(byteStream);
+    case 13:
+      return parseDefineFontInfo(byteStream);
     case 14:
       return parseDefineSound(byteStream);
     case 15:
       return parseStartSound(byteStream);
+    case 17:
+      return parseDefineButtonSound(byteStream);
     case 18:
       return parseSoundStreamHead(byteStream);
     case 19:
@@ -168,12 +175,18 @@ function parseTagBody(byteStream: ReadableByteStream, tagCode: Uint8, context: P
       return parseDefineBitsJpeg2(byteStream, context.getVersion());
     case 22:
       return parseDefineShape2(byteStream);
+    case 23:
+      return parseDefineButtonCxform(byteStream);
+    case 24:
+      return parseProtect(byteStream);
     case 26:
       return parsePlaceObject2(byteStream, context.getVersion());
     case 28:
       return parseRemoveObject2(byteStream);
     case 32:
       return parseDefineShape3(byteStream);
+    case 33:
+      return parseDefineText2(byteStream);
     case 34:
       return parseDefineButton2(byteStream);
     case 35:
@@ -190,14 +203,28 @@ function parseTagBody(byteStream: ReadableByteStream, tagCode: Uint8, context: P
       return parseSoundStreamHead2(byteStream);
     case 46:
       return parseDefineMorphShape(byteStream);
+    case 48:
+      return parseDefineFont2(byteStream);
     case 56:
       return parseExportAssets(byteStream);
     case 57:
       return parseImportAssets(byteStream);
+    case 58:
+      return parseEnableDebugger(byteStream);
     case 59:
       return parseDoInitAction(byteStream);
+    case 60:
+      return parseDefineVideoStream(byteStream);
+    case 61:
+      return parseVideoFrame(byteStream);
+    case 62:
+      return parseDefineFontInfo2(byteStream);
+    case 64:
+      return parseEnableDebugger2(byteStream);
     case 65:
       return parseScriptLimits(byteStream);
+    case 66:
+      return parseSetTabIndex(byteStream);
     case 69:
       return parseFileAttributes(byteStream);
     case 70:
@@ -214,6 +241,8 @@ function parseTagBody(byteStream: ReadableByteStream, tagCode: Uint8, context: P
       return parseSymbolClass(byteStream);
     case 77:
       return parseMetadata(byteStream);
+    case 78:
+      return parseDefineScalingGrid(byteStream);
     case 82:
       return parseDoAbc(byteStream);
     case 83:
@@ -222,12 +251,18 @@ function parseTagBody(byteStream: ReadableByteStream, tagCode: Uint8, context: P
       return parseDefineMorphShape2(byteStream);
     case 86:
       return parseDefineSceneAndFrameLabelData(byteStream);
+    case 87:
+      return parseDefineBinaryData(byteStream);
     case 88:
       return parseDefineFontName(byteStream);
     case 89:
       return parseStartSound2(byteStream);
     case 90:
       return parseDefineBitsJpeg4(byteStream, context.getVersion());
+    case 91:
+      return parseDefineFont4(byteStream);
+    case 93:
+      return parseEnableTelemetry(byteStream);
     default:
       console.warn(`UnknownTagType: Code ${tagCode}`);
       return {type: TagType.Unknown, code: tagCode, data: Uint8Array.from(byteStream.tailBytes())};
@@ -244,6 +279,10 @@ export function parseCsmTextSettings(byteStream: ReadableByteStream): tags.CsmTe
   const sharpness: Float32 = byteStream.readFloat32LE();
   byteStream.skip(1);
   return {type: TagType.CsmTextSettings, textId, renderer, fitting, thickness, sharpness};
+}
+
+export function parseDefineBinaryData(_byteStream: ReadableByteStream): tags.DefineBinaryData {
+  throw new Incident("NotImplemented", "parseDefineBinaryData");
 }
 
 export function parseDefineBits(byteStream: ReadableByteStream, swfVersion: Uint8): tags.DefineBitmap {
@@ -344,6 +383,10 @@ function parseDefineBitsLosslessAny(
   return {type: TagType.DefineBitmap, id, width, height, mediaType, data};
 }
 
+export function parseDefineButton(_byteStream: ReadableByteStream): tags.DefineButton {
+  throw new Incident("NotImplemented", "parseDefineButton");
+}
+
 export function parseDefineButton2(byteStream: ReadableByteStream): tags.DefineButton {
   const id: Uint16 = byteStream.readUint16LE();
   const flags: Uint8 = byteStream.readUint8();
@@ -363,6 +406,14 @@ export function parseDefineButton2(byteStream: ReadableByteStream): tags.DefineB
     actions = parseButton2CondActionString(byteStream);
   }
   return {type: TagType.DefineButton, id, trackAsMenu, characters, actions};
+}
+
+export function parseDefineButtonCxform(_byteStream: ReadableByteStream): never {
+  throw new Incident("NotImplemented", "parseDefineButtonCxform");
+}
+
+export function parseDefineButtonSound(_byteStream: ReadableByteStream): never {
+  throw new Incident("NotImplemented", "parseButtonSound");
 }
 
 export function parseDefineEditText(byteStream: ReadableByteStream): tags.DefineDynamicText {
@@ -431,6 +482,14 @@ export function parseDefineEditText(byteStream: ReadableByteStream): tags.Define
   };
 }
 
+export function parseDefineFont(_byteStream: ReadableByteStream): tags.DefineFont {
+  throw new Incident("NotImplemented", "parseDefineFont");
+}
+
+export function parseDefineFont2(_byteStream: ReadableByteStream): tags.DefineFont {
+  throw new Incident("NotImplemented", "parseDefineFont2");
+}
+
 // https://github.com/mozilla/shumway/blob/16451d8836fa85f4b16eeda8b4bda2fa9e2b22b0/src/swf/parser/module.ts#L632
 export function parseDefineFont3(byteStream: ReadableByteStream): tags.DefineFont {
   const id: Uint16 = byteStream.readUint16LE();
@@ -496,6 +555,10 @@ export function parseDefineFont3(byteStream: ReadableByteStream): tags.DefineFon
   };
 }
 
+export function parseDefineFont4(_byteStream: ReadableByteStream): tags.DefineFont {
+  throw new Incident("NotImplemented", "parseDefineFont4");
+}
+
 export function parseDefineFontAlignZones(
   byteStream: ReadableByteStream,
   glyphCountProvider: GlyphCountProvider,
@@ -513,6 +576,14 @@ export function parseDefineFontAlignZones(
     zones.push(parseFontAlignmentZone(byteStream));
   }
   return {type: TagType.DefineFontAlignZones, fontId, csmTableHint, zones};
+}
+
+export function parseDefineFontInfo(_byteStream: ReadableByteStream): tags.DefineFontInfo {
+  throw new Incident("NotImplemented", "parseDefineFontInfo");
+}
+
+export function parseDefineFontInfo2(_byteStream: ReadableByteStream): tags.DefineFontInfo {
+  throw new Incident("NotImplemented", "parseDefineFontInfo2");
 }
 
 export function parseDefineFontName(byteStream: ReadableByteStream): tags.DefineFontName {
@@ -572,6 +643,10 @@ export function parseDefineMorphShapeAny(
     hasNonScalingStrokes,
     shape,
   };
+}
+
+export function parseDefineScalingGrid(_byteStream: ReadableByteStream): never {
+  throw new Incident("NotImplemented", "parseDefineScalingGrid");
 }
 
 export function parseDefineSceneAndFrameLabelData(byteStream: ReadableByteStream): tags.DefineSceneAndFrameLabelData {
@@ -678,6 +753,14 @@ export function parseDefineText(byteStream: ReadableByteStream): tags.DefineText
   return {type: TagType.DefineText, id, bounds, matrix, records};
 }
 
+export function parseDefineText2(_byteStream: ReadableByteStream): tags.DefineText {
+  throw new Incident("NotImplemented", "parseDefineText2");
+}
+
+export function parseDefineVideoStream(_byteStream: ReadableByteStream): never {
+  throw new Incident("NotImplemented", "parseDefineVideoStream");
+}
+
 export function parseDoAbc(byteStream: ReadableByteStream): tags.DoAbc {
   const flags: Uint32 = byteStream.readUint32LE();
   const name: string = byteStream.readCString();
@@ -694,6 +777,18 @@ export function parseDoInitAction(byteStream: ReadableByteStream): tags.DoInitAc
   const spriteId: Uint16 = byteStream.readUint16LE();
   const actions: Uint8Array = Uint8Array.from(byteStream.tailBytes());
   return {type: TagType.DoInitAction, spriteId, actions};
+}
+
+export function parseEnableDebugger(_byteStream: ReadableByteStream): tags.EnableDebugger {
+  throw new Incident("NotImplemented", "parseEnableDebugger");
+}
+
+export function parseEnableDebugger2(_byteStream: ReadableByteStream): tags.EnableDebugger {
+  throw new Incident("NotImplemented", "parseEnableDebugger2");
+}
+
+export function parseEnableTelemetry(_byteStream: ReadableByteStream): never {
+  throw new Incident("NotImplemented", "parseEnableTelemetry");
 }
 
 export function parseExportAssets(byteStream: ReadableByteStream): tags.ExportAssets {
@@ -908,6 +1003,10 @@ export function parsePlaceObject3(byteStream: ReadableByteStream, swfVersion: Ui
   };
 }
 
+export function parseProtect(_byteStream: ReadableByteStream): never {
+  throw new Incident("NotImplemented", "parseProtect");
+}
+
 export function parseRemoveObject(byteStream: ReadableByteStream): tags.RemoveObject {
   const characterId: Uint16 = byteStream.readUint16LE();
   const depth: Uint16 = byteStream.readUint16LE();
@@ -927,6 +1026,10 @@ export function parseScriptLimits(byteStream: ReadableByteStream): tags.ScriptLi
 
 export function parseSetBackgroundColor(byteStream: ReadableByteStream): tags.SetBackgroundColor {
   return {type: TagType.SetBackgroundColor, color: parseSRgb8(byteStream)};
+}
+
+export function parseSetTabIndex(_byteStream: ReadableByteStream): never {
+  throw new Incident("NotImplemented", "parseSetTabIndex");
 }
 
 export function parseSoundStreamBlock(byteStream: ReadableByteStream): tags.SoundStreamBlock {
@@ -1000,4 +1103,8 @@ export function parseSymbolClass(byteStream: ReadableByteStream): tags.SymbolCla
     type: TagType.SymbolClass,
     symbols,
   };
+}
+
+export function parseVideoFrame(_byteStream: ReadableByteStream): never {
+  throw new Incident("NotImplemented", "parseVideoFrame");
 }


### PR DESCRIPTION
This commit adds placeholder parsers for all the remaining tags defined by the SWF spec. This allows to better track the overall progress of the parser and provide better errors to consumers. According to the Rust implementation 45 out of 64 parsers are implemented.