### PR TITLE
[ts] Replace `zlib` dependency with `pako`

### DIFF
--- a/ts/package.json
+++ b/ts/package.json
@@ -25,7 +25,9 @@
   },
   "dependencies": {
     "@open-flash/stream": "^0.1.0",
+    "@types/pako": "^1.0.1",
     "incident": "^3.2.0",
+    "pako": "^1.0.10",
     "semantic-types": "^0.1.1",
     "swf-tree": "^0.5.0"
   },

--- a/ts/src/lib/parsers/movie.ts
+++ b/ts/src/lib/parsers/movie.ts
@@ -1,8 +1,8 @@
 import { ReadableStream } from "@open-flash/stream";
 import { Incident } from "incident";
+import { inflate } from "pako";
 import { Uint8 } from "semantic-types";
 import { CompressionMethod, Header, Movie, SwfSignature, Tag } from "swf-tree";
-import * as zlib from "zlib";
 import { DefaultParseContext, ParseContext } from "../parse-context";
 import { parseHeader, parseSwfSignature } from "./header";
 import { parseTagBlockString } from "./tags";
@@ -14,9 +14,8 @@ export function parseMovie(byteStream: ReadableStream): Movie {
       return parsePayload(byteStream, signature.swfVersion);
     case CompressionMethod.Deflate:
       const tail: Uint8Array = byteStream.tailBytes();
-      const tailBuffer: Buffer = Buffer.from(tail);
-      const deflated: Buffer = zlib.inflateSync(tailBuffer);
-      const payloadStream: ReadableStream = new ReadableStream(deflated);
+      const payload: Uint8Array = inflate(tail);
+      const payloadStream: ReadableStream = new ReadableStream(payload);
       return parsePayload(payloadStream, signature.swfVersion);
     case CompressionMethod.Lzma:
       throw new Incident("NotImplemented", "Support for LZMA compression is not implemented yet");

--- a/ts/yarn.lock
+++ b/ts/yarn.lock
@@ -340,6 +340,11 @@
   resolved "https://registry.yarnpkg.com/@types/os-homedir/-/os-homedir-1.0.0.tgz#b134048d1567ce1b1524abc1e73cd36df6ad8ead"
   integrity sha1-sTQEjRVnzhsVJKvB5zzTbfatjq0=
 
+"@types/pako@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@types/pako/-/pako-1.0.1.tgz#33b237f3c9aff44d0f82fe63acffa4a365ef4a61"
+  integrity sha512-GdZbRSJ3Cv5fiwT6I0SQ3ckeN2PWNqxd26W9Z2fCK1tGrrasGy4puvNFtnddqH9UJFMQYXxEuuB7B8UK+LLwSg==
+
 "@types/rimraf@^2.0.2":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@types/rimraf/-/rimraf-2.0.2.tgz#7f0fc3cf0ff0ad2a99bb723ae1764f30acaf8b6e"
@@ -1052,11 +1057,6 @@ commander@2.11.x:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
   integrity sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==
-
-commander@2.15.1:
-  version "2.15.1"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
-  integrity sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==
 
 commander@2.19.0:
   version "2.19.0"
@@ -2743,26 +2743,9 @@ mkdirp@0.5.1, mkdirp@^0.5.0, mkdirp@^0.5.1:
   dependencies:
     minimist "0.0.8"
 
-mocha@^5.2.0:
+mocha@^5.2.0, "mocha@git://github.com/mochajs/mocha#955a71e971d77505f3772be0e2ffcf03ef814f58":
   version "5.2.0"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-5.2.0.tgz#6d8ae508f59167f940f2b5b3c4a612ae50c90ae6"
-  integrity sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==
-  dependencies:
-    browser-stdout "1.3.1"
-    commander "2.15.1"
-    debug "3.1.0"
-    diff "3.5.0"
-    escape-string-regexp "1.0.5"
-    glob "7.1.2"
-    growl "1.10.5"
-    he "1.1.1"
-    minimatch "3.0.4"
-    mkdirp "0.5.1"
-    supports-color "5.4.0"
-
-"mocha@git://github.com/mochajs/mocha.git#955a71e971d77505f3772be0e2ffcf03ef814f58":
-  version "5.2.0"
-  resolved "git://github.com/mochajs/mocha.git#955a71e971d77505f3772be0e2ffcf03ef814f58"
+  resolved "git://github.com/mochajs/mocha#955a71e971d77505f3772be0e2ffcf03ef814f58"
   dependencies:
     browser-stdout "1.3.1"
     commander "2.19.0"
@@ -3112,6 +3095,11 @@ p-try@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
+
+pako@^1.0.10:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.10.tgz#4328badb5086a426aa90f541977d4955da5c9732"
+  integrity sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==
 
 parse-filepath@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
This commit fixes the dependency on Node's `zlib` in favor of `pako`. It should provide better better browser support. It also removes one of the last points where Node's `Buffer` was required (in favor of simply `Uint8Array`).