### PR TITLE
[rs] Rename `parse_swf_tag` to `parse_tag`

### DIFF
--- a/rs/src/lib.rs
+++ b/rs/src/lib.rs
@@ -35,7 +35,7 @@ mod lib_tests {
   use ::test_generator::test_expand_paths;
 
   use crate::parsers::movie::parse_movie;
-  use crate::parsers::tags::parse_swf_tag;
+  use crate::parsers::tags::parse_tag;
   use crate::state::ParseState;
 
   test_expand_paths! { test_parse_movie; "../tests/movies/*/" }
@@ -78,7 +78,7 @@ mod lib_tests {
 
     let mut state = ParseState::new(10);
     state.set_glyph_count(1, 11);
-    let (remaining_bytes, actual_value) = parse_swf_tag(&input_bytes, &mut state).expect("Failed to parse");
+    let (remaining_bytes, actual_value) = parse_tag(&input_bytes, &mut state).expect("Failed to parse");
 
     let expected_path = path.join("value.json");
     let expected_file = ::std::fs::File::open(expected_path).expect("Failed to open expected value file");

--- a/rs/src/parsers/movie.rs
+++ b/rs/src/parsers/movie.rs
@@ -1,6 +1,6 @@
 use nom::{IResult as NomResult, Needed};
 use crate::parsers::header::{parse_header, parse_swf_signature};
-use crate::parsers::tags::parse_swf_tag;
+use crate::parsers::tags::parse_tag;
 use crate::state::ParseState;
 use swf_tree as ast;
 
@@ -13,7 +13,7 @@ pub fn parse_tag_block_string<'a>(input: &'a [u8], state: &mut ParseState) -> No
       current_input = &current_input[1..];
       break;
     }
-    match parse_swf_tag(current_input, state) {
+    match parse_tag(current_input, state) {
       Ok((next_input, swf_tag)) => {
         current_input = next_input;
         result.push(swf_tag);

--- a/rs/src/parsers/tags.rs
+++ b/rs/src/parsers/tags.rs
@@ -45,7 +45,7 @@ fn parse_tag_header(input: &[u8]) -> IResult<&[u8], ast::TagHeader> {
   }
 }
 
-pub fn parse_swf_tag<'a>(input: &'a [u8], state: &mut ParseState) -> IResult<&'a [u8], ast::Tag> {
+pub fn parse_tag<'a>(input: &'a [u8], state: &mut ParseState) -> IResult<&'a [u8], ast::Tag> {
   use std::convert::TryInto;
 
   match parse_tag_header(input) {


### PR DESCRIPTION
For consistency with the Typescript implementation and naming convention in the lib, this commit renames Rust's `parse_swf_tag` to `parse_tag`.