### PR TITLE
[all] Release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Next
+# 0.5.0 (2019-04-22)
 
 - **[Breaking change]** Update to `swf-tree@0.6.0`.
 - **[Internal]** Refactor tests.
@@ -12,7 +12,7 @@
 
 - **[Breaking change]** Rename `parse_swf_tag` to `parse_tag`.
 
-# 0.4.0 (2019-01-14)
+# 0.4.0 (2019-04-14)
 
 - **[Breaking change]** Update to `swf-tree@0.5.0`.
 

--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "swf-parser"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "half 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "inflate 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swf-parser"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Charles Samborski <demurgos@demurgos.net>"]
 description = "SWF parser"
 documentation = "https://github.com/open-flash/swf-parser"

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swf-parser",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "SWF parser loosely based on Shumway",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",


### PR DESCRIPTION
- **[Breaking change]** Update to `swf-tree@0.6.0`.
- **[Internal]** Refactor tests.
- **[Internal]** Add `CHANGELOG.md`

### Typescript

- **[Fix]** Inflate zlib payloads with `pako` instead of Node's `zlib` (should improve browser support).

### Rust

- **[Breaking change]** Rename `parse_swf_tag` to `parse_tag`.