### PR TITLE
[all] Release v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Next
+# 0.5.2 (2019-04-26)
 
 - **[Fix]** Ensure `align` is always defined in `DefineDynamicText`.
 - **[Internal]** Update test samples.

--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "swf-parser"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "half 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "inflate 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swf-parser"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Charles Samborski <demurgos@demurgos.net>"]
 description = "SWF parser"
 documentation = "https://github.com/open-flash/swf-parser"

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swf-parser",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "SWF parser loosely based on Shumway",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",


### PR DESCRIPTION
- **[Fix]** Ensure `align` is always defined in `DefineDynamicText`.
- **[Internal]** Update test samples.

### Rust

- **[Fix]** Fix support for `PlaceObject1` with `ColorTransform`.