### PR TITLE
Implement parsers for DefineBinaryData tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Next
 
+- **[Feature]** Implement parser for `DefineBinaryData` (thanks [@dmarcuse](https://github.com/dmarcuse)).
 - **[Fix]** Parse PNG integers as big endians.
 
 ### Rust

--- a/rs/src/parsers/tags.rs
+++ b/rs/src/parsers/tags.rs
@@ -172,8 +172,12 @@ pub fn parse_csm_text_settings(input: &[u8]) -> IResult<&[u8], ast::tags::CsmTex
   )
 }
 
-pub fn parse_define_binary_data(_input: &[u8]) -> IResult<&[u8], ast::tags::DefineBinaryData> {
-  unimplemented!()
+pub fn parse_define_binary_data(input: &[u8]) -> IResult<&[u8], ast::tags::DefineBinaryData> {
+  let (input, id) = parse_le_u16(input)?;
+  let (input, _reserved) = parse_le_u32(input)?; // TODO: assert reserved == 0
+  let data = input.to_vec();
+  let input = &[][..];
+  Ok((input, ast::tags::DefineBinaryData { id, data }))
 }
 
 pub fn parse_define_bits(input: &[u8], swf_version: u8) -> IResult<&[u8], ast::tags::DefineBitmap> {

--- a/ts/src/lib/parsers/tags.ts
+++ b/ts/src/lib/parsers/tags.ts
@@ -285,8 +285,11 @@ export function parseCsmTextSettings(byteStream: ReadableByteStream): tags.CsmTe
   return {type: TagType.CsmTextSettings, textId, renderer, fitting, thickness, sharpness};
 }
 
-export function parseDefineBinaryData(_byteStream: ReadableByteStream): tags.DefineBinaryData {
-  throw new Incident("NotImplemented", "parseDefineBinaryData");
+export function parseDefineBinaryData(byteStream: ReadableByteStream): tags.DefineBinaryData {
+  const id: Uint16 = byteStream.readUint16LE();
+  byteStream.readUint32LE(); // TODO: assert == 0
+  const data: Uint8Array = byteStream.tailBytes();
+  return {type: TagType.DefineBinaryData, id, data};
 }
 
 export function parseDefineBits(byteStream: ReadableByteStream, swfVersion: Uint8): tags.DefineBitmap {


### PR DESCRIPTION
I've implemented parsers (for both Rust and Typescript) for the DefineBinaryData tag, closing #46. I've done some testing locally, but if you have an SWF you'd like to use for testing this, I can implement a test for it as well.