### PR TITLE
[all] Release v0.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Next
+# 0.5.3 (2019-05-05)
 
 - **[Feature]** Implement parser for `DefineBinaryData` (thanks [@dmarcuse](https://github.com/dmarcuse)).
 - **[Fix]** Parse PNG integers as big endians.

--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "swf-parser"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "half 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "inflate 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swf-parser"
-version = "0.5.2"
+version = "0.5.3"
 authors = ["Charles Samborski <demurgos@demurgos.net>"]
 description = "SWF parser"
 documentation = "https://github.com/open-flash/swf-parser"

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swf-parser",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "SWF parser loosely based on Shumway",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",


### PR DESCRIPTION
- **[Feature]** Implement parser for `DefineBinaryData` (thanks [@dmarcuse](https://github.com/dmarcuse)).
- **[Fix]** Parse PNG integers as big endians.

### Rust

- **[Fix]** Stop at end of block or nul byte (whichever comes first) when parsing `DefineFont3`.

### Typescript

- **[Internal]** Update build tools.