### PR TITLE
[all] Update `Contributing` sections in `README.md`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Next
 
 - **[Feature]** Implement parser for `DefineFont2` ([#38](https://github.com/open-flash/swf-parser/issues/38)).
+- **[Internal]** Update `Contributing` sections in `README.md`. 
 
 ### Typescript
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ Help is welcome to complete the parser.
 
 ## Contributing
 
+Each implementation lives in its own directory (`rs` or `ts`). The commands
+must be executed from these "project roots", not from the "repo root".
+
+Check the implementation-specific guides:
+
 - [Rust](./rs/README.md#contributing)
 - [Typescript](./ts/README.md#contributing)
 

--- a/rs/README.md
+++ b/rs/README.md
@@ -37,7 +37,7 @@ git submodule update --init --recursive --remote
 ```
 
 This library is a standard Cargo project. You can test your changes with
-`cargo test`.
+`cargo test`.  **The commands must be run from the `rs` directory.**
 
 The Rust implementation supports fuzzing:
 

--- a/ts/README.md
+++ b/ts/README.md
@@ -40,9 +40,10 @@ git submodule update --init --recursive --remote
 ```
 
 This library uses Gulp and npm for its builds, yarn is recommended for the
-dependencies.
+dependencies. **The commands must be run from the `ts` directory.**
 
 ```
+cd ts
 npm install
 # work your changes...
 npm test


### PR DESCRIPTION
This commit clarifies that the project commands must be run from the `rs` or `ts` directories, not the repo root.