### PR TITLE
[rs] Add rustfmt to project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,9 @@ matrix:
 #        - stable
       before_script:
         - cd rs
+        - rustup component add rustfmt
       script:
+        - cargo fmt --all -- --check
         - cargo build
         - cargo test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 - **[Feature]** Implement parser for `DefineFontInfo` ([#33](https://github.com/open-flash/swf-parser/issues/33)).
 - **[Fix]** Fix support for non-extended (SWF version < 6) clip actions in `PlaceObject2`.
 
+### Rust
+
+- **[Internal]** Add `rustfmt` support (thanks [@pheki](https://github.com/pheki)) ([#25](https://github.com/open-flash/swf-parser/issues/25))
+
 # 0.7.0 (2019-05-21)
 
 - **[Breaking change]** Update to `swf-tree@0.7`.

--- a/rs/rustfmt.toml
+++ b/rs/rustfmt.toml
@@ -1,0 +1,2 @@
+max_width = 120
+tab_spaces = 2

--- a/rs/src/lib.rs
+++ b/rs/src/lib.rs
@@ -42,7 +42,13 @@ mod tests {
     use serde::Serialize;
 
     let path: &Path = Path::new(path);
-    let _name = path.components().last().unwrap().as_os_str().to_str().expect("Failed to retrieve sample name");
+    let _name = path
+      .components()
+      .last()
+      .unwrap()
+      .as_os_str()
+      .to_str()
+      .expect("Failed to retrieve sample name");
     let movie_path = path.join("main.swf");
     let mut movie_file = ::std::fs::File::open(movie_path).expect("Failed to open movie");
     let mut movie_bytes: Vec<u8> = Vec::new();
@@ -71,7 +77,13 @@ mod tests {
   test_expand_paths! { test_parse_tag; "../tests/tags/*/*/" }
   fn test_parse_tag(path: &str) {
     let path: &Path = Path::new(path);
-    let name = path.components().last().unwrap().as_os_str().to_str().expect("Failed to retrieve sample name");
+    let name = path
+      .components()
+      .last()
+      .unwrap()
+      .as_os_str()
+      .to_str()
+      .expect("Failed to retrieve sample name");
     let input_path = path.join("input.bytes");
     let input_bytes: Vec<u8> = ::std::fs::read(input_path).expect("Failed to read input");
 
@@ -98,7 +110,13 @@ mod tests {
       test_expand_paths! { $name; $glob }
       fn $name(path: &str) {
         let path: &Path = Path::new(path);
-        let _name = path.components().last().unwrap().as_os_str().to_str().expect("Failed to retrieve sample name");
+        let _name = path
+          .components()
+          .last()
+          .unwrap()
+          .as_os_str()
+          .to_str()
+          .expect("Failed to retrieve sample name");
         let input_path = path.join("input.bytes");
         let input_bytes: Vec<u8> = ::std::fs::read(input_path).expect("Failed to read input");
 
@@ -112,7 +130,7 @@ mod tests {
         assert_eq!(actual_value, expected_value);
         assert_eq!(remaining_bytes, &[] as &[u8]);
       }
-    }
+    };
   }
 
   use crate::parsers::basic_data_types::parse_le_f16;
@@ -136,8 +154,18 @@ mod tests {
 
   use crate::parsers::header::parse_swf_signature;
   use swf_tree::SwfSignature;
-  test_various_parser_impl!(test_parse_swf_signature, "../tests/various/swf-signature/*/", parse_swf_signature, SwfSignature);
+  test_various_parser_impl!(
+    test_parse_swf_signature,
+    "../tests/various/swf-signature/*/",
+    parse_swf_signature,
+    SwfSignature
+  );
 
   use crate::parsers::basic_data_types::parse_leb128_u32;
-  test_various_parser_impl!(test_parse_leb128_u32, "../tests/various/uint32-leb128/*/", parse_leb128_u32, u32);
+  test_various_parser_impl!(
+    test_parse_leb128_u32,
+    "../tests/various/uint32-leb128/*/",
+    parse_leb128_u32,
+    u32
+  );
 }

--- a/rs/src/main.rs
+++ b/rs/src/main.rs
@@ -16,13 +16,13 @@ fn main() {
   }
 
   let file_path = &args[1];
-//  println!("Reading file: {}", filename);
+  //  println!("Reading file: {}", filename);
 
   let mut file = File::open(file_path).expect("File not found");
   let mut data: Vec<u8> = Vec::new();
   file.read_to_end(&mut data).expect("Unable to read file");
 
-//  println!("Input:\n{:?}", &data);
+  //  println!("Input:\n{:?}", &data);
 
   let swf_file_parse_result: nom::IResult<&[u8], ast::Movie> = parsers::movie::parse_movie(&data[..]);
 

--- a/rs/src/parsers/button.rs
+++ b/rs/src/parsers/button.rs
@@ -1,7 +1,7 @@
-use nom::{le_u16 as parse_le_u16, le_u8 as parse_u8};
-use nom::IResult as NomResult;
 use crate::parsers::basic_data_types::{parse_color_transform_with_alpha, parse_matrix};
 use crate::parsers::display::{parse_blend_mode, parse_filter_list};
+use nom::IResult as NomResult;
+use nom::{le_u16 as parse_le_u16, le_u8 as parse_u8};
 use swf_tree as ast;
 
 #[derive(PartialEq, Eq, Clone, Copy, Ord, PartialOrd)]
@@ -88,7 +88,10 @@ pub fn parse_button2_cond_action_string(input: &[u8]) -> NomResult<&[u8], Vec<as
     } else {
       let next_action_offset = next_action_offset as usize;
       let le_u16_size = current_input.len() - input.len();
-      (&current_input[le_u16_size..next_action_offset], &current_input[next_action_offset..])
+      (
+        &current_input[le_u16_size..next_action_offset],
+        &current_input[next_action_offset..],
+      )
     };
 
     match parse_button2_cond_action(input) {
@@ -126,28 +129,28 @@ pub fn parse_button_cond(input: &[u8]) -> NomResult<&[u8], ast::ButtonCond> {
 
   do_parse!(
     input,
-    flags: parse_le_u16 >>
-    idle_to_over_up: value!((flags & (1 << 0)) != 0) >>
-    over_up_to_idle: value!((flags & (1 << 1)) != 0) >>
-    over_up_to_over_down: value!((flags & (1 << 2)) != 0) >>
-    over_down_to_over_up: value!((flags & (1 << 3)) != 0) >>
-    over_down_to_out_down: value!((flags & (1 << 4)) != 0) >>
-    out_down_to_over_down: value!((flags & (1 << 5)) != 0) >>
-    out_down_to_idle: value!((flags & (1 << 6)) != 0) >>
-    idle_to_over_down: value!((flags & (1 << 7)) != 0) >>
-    over_down_to_idle: value!((flags & (1 << 8)) != 0) >>
-    key_press: map!(value!((flags >> 9) & 0x7f), key_press_from_id) >>
-    (ast::ButtonCond {
-      key_press,
-      over_down_to_idle,
-      idle_to_over_up,
-      over_up_to_idle,
-      over_up_to_over_down,
-      over_down_to_over_up,
-      over_down_to_out_down,
-      out_down_to_over_down,
-      out_down_to_idle,
-      idle_to_over_down,
-    })
+    flags: parse_le_u16
+      >> idle_to_over_up: value!((flags & (1 << 0)) != 0)
+      >> over_up_to_idle: value!((flags & (1 << 1)) != 0)
+      >> over_up_to_over_down: value!((flags & (1 << 2)) != 0)
+      >> over_down_to_over_up: value!((flags & (1 << 3)) != 0)
+      >> over_down_to_out_down: value!((flags & (1 << 4)) != 0)
+      >> out_down_to_over_down: value!((flags & (1 << 5)) != 0)
+      >> out_down_to_idle: value!((flags & (1 << 6)) != 0)
+      >> idle_to_over_down: value!((flags & (1 << 7)) != 0)
+      >> over_down_to_idle: value!((flags & (1 << 8)) != 0)
+      >> key_press: map!(value!((flags >> 9) & 0x7f), key_press_from_id)
+      >> (ast::ButtonCond {
+        key_press,
+        over_down_to_idle,
+        idle_to_over_up,
+        over_up_to_idle,
+        over_up_to_over_down,
+        over_down_to_over_up,
+        over_down_to_out_down,
+        out_down_to_over_down,
+        out_down_to_idle,
+        idle_to_over_down,
+      })
   )
 }

--- a/rs/src/parsers/gradient.rs
+++ b/rs/src/parsers/gradient.rs
@@ -1,21 +1,22 @@
-use swf_tree as ast;
-use nom::IResult;
-use nom::{le_u8 as parse_u8};
 use crate::parsers::basic_data_types::{parse_s_rgb8, parse_straight_s_rgba8};
+use nom::le_u8 as parse_u8;
+use nom::IResult;
+use swf_tree as ast;
 
 #[allow(unused_variables)]
 pub fn parse_color_stop(input: &[u8], with_alpha: bool) -> IResult<&[u8], ast::ColorStop> {
   do_parse!(
     input,
-    ratio: parse_u8 >>
-    color: switch!(value!(with_alpha),
-      true => call!(parse_straight_s_rgba8) |
-      false => map!(parse_s_rgb8, |c| ast::StraightSRgba8 {r: c.r, g: c.g, b: c.b, a: 255})
-    ) >>
-    (ast::ColorStop {
-      ratio: ratio,
-      color: color,
-    })
+    ratio: parse_u8
+      >> color:
+        switch!(value!(with_alpha),
+          true => call!(parse_straight_s_rgba8) |
+          false => map!(parse_s_rgb8, |c| ast::StraightSRgba8 {r: c.r, g: c.g, b: c.b, a: 255})
+        )
+      >> (ast::ColorStop {
+        ratio: ratio,
+        color: color,
+      })
   )
 }
 
@@ -23,27 +24,29 @@ pub fn parse_color_stop(input: &[u8], with_alpha: bool) -> IResult<&[u8], ast::C
 pub fn parse_gradient(input: &[u8], with_alpha: bool) -> IResult<&[u8], ast::Gradient> {
   do_parse!(
     input,
-    flags: parse_u8 >>
-    spread_id: value!(flags >> 6) >>
-    color_space_id: value!((flags & ((1 << 6) - 1)) >> 4) >>
-    color_count: value!(flags & ((1 << 4) - 1)) >>
-    spread: switch!(value!(spread_id),
-      0 => value!(ast::GradientSpread::Pad) |
-      1 => value!(ast::GradientSpread::Reflect) |
-      2 => value!(ast::GradientSpread::Repeat)
-      // TODO: Default to error
-    ) >>
-    color_space: switch!(value!(color_space_id),
-      0 => value!(ast::ColorSpace::SRgb) |
-      1 => value!(ast::ColorSpace::LinearRgb)
-      // TODO: Default to error
-    ) >>
-    colors: length_count!(value!(color_count), apply!(parse_color_stop, with_alpha)) >>
-    (ast::Gradient {
-      spread: spread,
-      color_space: color_space,
-      colors: colors,
-    })
+    flags: parse_u8
+      >> spread_id: value!(flags >> 6)
+      >> color_space_id: value!((flags & ((1 << 6) - 1)) >> 4)
+      >> color_count: value!(flags & ((1 << 4) - 1))
+      >> spread:
+        switch!(value!(spread_id),
+          0 => value!(ast::GradientSpread::Pad) |
+          1 => value!(ast::GradientSpread::Reflect) |
+          2 => value!(ast::GradientSpread::Repeat)
+          // TODO: Default to error
+        )
+      >> color_space:
+        switch!(value!(color_space_id),
+          0 => value!(ast::ColorSpace::SRgb) |
+          1 => value!(ast::ColorSpace::LinearRgb)
+          // TODO: Default to error
+        )
+      >> colors: length_count!(value!(color_count), apply!(parse_color_stop, with_alpha))
+      >> (ast::Gradient {
+        spread: spread,
+        color_space: color_space,
+        colors: colors,
+      })
   )
 }
 
@@ -51,14 +54,14 @@ pub fn parse_gradient(input: &[u8], with_alpha: bool) -> IResult<&[u8], ast::Gra
 pub fn parse_morph_color_stop(input: &[u8], with_alpha: bool) -> IResult<&[u8], ast::MorphColorStop> {
   do_parse!(
     input,
-    start: apply!(parse_color_stop, with_alpha) >>
-    end: apply!(parse_color_stop, with_alpha) >>
-    (ast::MorphColorStop {
-      ratio: start.ratio,
-      color: start.color,
-      morph_ratio: end.ratio,
-      morph_color: end.color,
-    })
+    start: apply!(parse_color_stop, with_alpha)
+      >> end: apply!(parse_color_stop, with_alpha)
+      >> (ast::MorphColorStop {
+        ratio: start.ratio,
+        color: start.color,
+        morph_ratio: end.ratio,
+        morph_color: end.color,
+      })
   )
 }
 
@@ -66,26 +69,28 @@ pub fn parse_morph_color_stop(input: &[u8], with_alpha: bool) -> IResult<&[u8], 
 pub fn parse_morph_gradient(input: &[u8], with_alpha: bool) -> IResult<&[u8], ast::MorphGradient> {
   do_parse!(
     input,
-    flags: parse_u8 >>
-    spread_id: value!(flags >> 6) >>
-    color_space_id: value!((flags & ((1 << 6) - 1)) >> 4) >>
-    color_count: value!(flags & ((1 << 4) - 1)) >>
-    spread: switch!(value!(spread_id),
-      0 => value!(ast::GradientSpread::Pad) |
-      1 => value!(ast::GradientSpread::Reflect) |
-      2 => value!(ast::GradientSpread::Repeat)
-      // TODO: Default to error
-    ) >>
-    color_space: switch!(value!(color_space_id),
-      0 => value!(ast::ColorSpace::SRgb) |
-      1 => value!(ast::ColorSpace::LinearRgb)
-      // TODO: Default to error
-    ) >>
-    colors: length_count!(value!(color_count), apply!(parse_morph_color_stop, with_alpha)) >>
-    (ast::MorphGradient {
-      spread: spread,
-      color_space: color_space,
-      colors: colors,
-    })
+    flags: parse_u8
+      >> spread_id: value!(flags >> 6)
+      >> color_space_id: value!((flags & ((1 << 6) - 1)) >> 4)
+      >> color_count: value!(flags & ((1 << 4) - 1))
+      >> spread:
+        switch!(value!(spread_id),
+          0 => value!(ast::GradientSpread::Pad) |
+          1 => value!(ast::GradientSpread::Reflect) |
+          2 => value!(ast::GradientSpread::Repeat)
+          // TODO: Default to error
+        )
+      >> color_space:
+        switch!(value!(color_space_id),
+          0 => value!(ast::ColorSpace::SRgb) |
+          1 => value!(ast::ColorSpace::LinearRgb)
+          // TODO: Default to error
+        )
+      >> colors: length_count!(value!(color_count), apply!(parse_morph_color_stop, with_alpha))
+      >> (ast::MorphGradient {
+        spread: spread,
+        color_space: color_space,
+        colors: colors,
+      })
   )
 }

--- a/rs/src/parsers/header.rs
+++ b/rs/src/parsers/header.rs
@@ -1,6 +1,6 @@
-use nom::{le_u16 as parse_le_u16, le_u32 as parse_le_u32, le_u8 as parse_u8};
-use nom::IResult;
 use crate::parsers::basic_data_types::{parse_le_ufixed8_p8, parse_rect};
+use nom::IResult;
+use nom::{le_u16 as parse_le_u16, le_u32 as parse_le_u32, le_u8 as parse_u8};
 use swf_tree as ast;
 
 pub fn parse_compression_method(input: &[u8]) -> IResult<&[u8], ast::CompressionMethod> {
@@ -16,29 +16,29 @@ pub fn parse_compression_method(input: &[u8]) -> IResult<&[u8], ast::Compression
 pub fn parse_swf_signature(input: &[u8]) -> IResult<&[u8], ast::SwfSignature> {
   do_parse!(
     input,
-    compression_method: parse_compression_method >>
-    swf_version: parse_u8 >>
-    uncompressed_file_length: map!(parse_le_u32, |x| x as usize) >>
-    (ast::SwfSignature {
-      compression_method: compression_method,
-      swf_version: swf_version,
-      uncompressed_file_length: uncompressed_file_length,
-    })
+    compression_method: parse_compression_method
+      >> swf_version: parse_u8
+      >> uncompressed_file_length: map!(parse_le_u32, |x| x as usize)
+      >> (ast::SwfSignature {
+        compression_method: compression_method,
+        swf_version: swf_version,
+        uncompressed_file_length: uncompressed_file_length,
+      })
   )
 }
 
 pub fn parse_header(input: &[u8], swf_version: u8) -> IResult<&[u8], ast::Header> {
   do_parse!(
     input,
-    frame_size: parse_rect >>
-    frame_rate: parse_le_ufixed8_p8 >>
-    frame_count: parse_le_u16 >>
-    (ast::Header {
-      swf_version: swf_version,
-      frame_size: frame_size,
-      frame_rate: frame_rate,
-      frame_count: frame_count,
-    })
+    frame_size: parse_rect
+      >> frame_rate: parse_le_ufixed8_p8
+      >> frame_count: parse_le_u16
+      >> (ast::Header {
+        swf_version: swf_version,
+        frame_size: frame_size,
+        frame_rate: frame_rate,
+        frame_count: frame_count,
+      })
   )
 }
 
@@ -48,9 +48,18 @@ mod tests {
 
   #[test]
   fn test_parse_compression_method() {
-    assert_eq!(parse_compression_method(&b"FWS"[..]), Ok((&[][..], ast::CompressionMethod::None)));
-    assert_eq!(parse_compression_method(&b"CWS"[..]), Ok((&[][..], ast::CompressionMethod::Deflate)));
-    assert_eq!(parse_compression_method(&b"ZWS"[..]), Ok((&[][..], ast::CompressionMethod::Lzma)));
+    assert_eq!(
+      parse_compression_method(&b"FWS"[..]),
+      Ok((&[][..], ast::CompressionMethod::None))
+    );
+    assert_eq!(
+      parse_compression_method(&b"CWS"[..]),
+      Ok((&[][..], ast::CompressionMethod::Deflate))
+    );
+    assert_eq!(
+      parse_compression_method(&b"ZWS"[..]),
+      Ok((&[][..], ast::CompressionMethod::Lzma))
+    );
   }
 
   #[test]

--- a/rs/src/parsers/image.rs
+++ b/rs/src/parsers/image.rs
@@ -28,7 +28,10 @@ pub fn get_png_image_dimensions(input: &[u8]) -> Result<ImageDimensions, ()> {
   let (input, width) = parse_be_u32(input).unwrap();
   let (_, height) = parse_be_u32(input).unwrap();
 
-  Ok(ImageDimensions { width: width as usize, height: height as usize })
+  Ok(ImageDimensions {
+    width: width as usize,
+    height: height as usize,
+  })
 }
 
 pub fn get_jpeg_image_dimensions(input: &[u8]) -> Result<ImageDimensions, ()> {
@@ -41,7 +44,10 @@ pub fn get_jpeg_image_dimensions(input: &[u8]) -> Result<ImageDimensions, ()> {
       let frame_height: u16 = ((chunk[5] as u16) << 8) + (chunk[6] as u16);
       let frame_width: u16 = ((chunk[7] as u16) << 8) + (chunk[8] as u16);
       dimensions = match dimensions {
-        None => Some(ImageDimensions { width: frame_width as usize, height: frame_height as usize }),
+        None => Some(ImageDimensions {
+          width: frame_width as usize,
+          height: frame_height as usize,
+        }),
         d => d,
       };
     }
@@ -64,13 +70,14 @@ fn read_jpeg_chunks(input: &[u8]) -> Vec<&[u8]> {
     if (code >= 0xc0 && code <= 0xc7)
       || (code >= 0xc9 && code <= 0xcf)
       || (code >= 0xda && code <= 0xef)
-      || code == 0xfe {
+      || code == 0xfe
+    {
       size += ((chunk[2] as usize) << 8) + (chunk[3] as usize);
     }
     next_chunk_start = find_next_chunk(&chunk[size..]);
     match &next_chunk_start {
       Some(next) => result.push(&chunk[..(chunk.len() - next.len())]),
-      None => result.push(chunk)
+      None => result.push(chunk),
     }
   }
 
@@ -101,7 +108,10 @@ pub fn get_gif_image_dimensions(input: &[u8]) -> Result<ImageDimensions, ()> {
   let (input, width) = parse_be_u16(input).unwrap();
   let (_, height) = parse_be_u16(input).unwrap();
 
-  Ok(ImageDimensions { width: width as usize, height: height as usize })
+  Ok(ImageDimensions {
+    width: width as usize,
+    height: height as usize,
+  })
 }
 
 pub fn test_image_start(image_data: &[u8], start_bytes: &[u8]) -> bool {

--- a/rs/src/parsers/movie.rs
+++ b/rs/src/parsers/movie.rs
@@ -1,7 +1,7 @@
-use nom::{IResult as NomResult, Needed};
 use crate::parsers::header::{parse_header, parse_swf_signature};
 use crate::parsers::tags::parse_tag;
 use crate::state::ParseState;
+use nom::{IResult as NomResult, Needed};
 use swf_tree as ast;
 
 pub fn parse_tag_block_string<'a>(input: &'a [u8], state: &mut ParseState) -> NomResult<&'a [u8], Vec<ast::Tag>> {
@@ -30,12 +30,12 @@ pub fn parse_movie_payload(input: &[u8], swf_version: u8) -> NomResult<&[u8], as
   let mut state = ParseState::new(swf_version);
   do_parse!(
     input,
-    header: call!(parse_header, swf_version) >>
-    tags: apply!(parse_tag_block_string, &mut state) >>
-    (ast::Movie {
-      header: header,
-      tags: tags,
-    })
+    header: call!(parse_header, swf_version)
+      >> tags: apply!(parse_tag_block_string, &mut state)
+      >> (ast::Movie {
+        header: header,
+        tags: tags,
+      })
   )
 }
 
@@ -52,13 +52,15 @@ pub fn parse_movie(input: &[u8]) -> NomResult<&[u8], ast::Movie> {
 
       match parse_movie_payload(&payload[..], signature.swf_version) {
         Ok((_, movie)) => Ok((&[][..], movie)),
-        Err(::nom::Err::Error(::nom::simple_errors::Context::Code(_, e))) => Err(::nom::Err::Error(::nom::simple_errors::Context::Code(&[][..], e))),
-        Err(::nom::Err::Failure(::nom::simple_errors::Context::Code(_, e))) => Err(::nom::Err::Failure(::nom::simple_errors::Context::Code(&[][..], e))),
+        Err(::nom::Err::Error(::nom::simple_errors::Context::Code(_, e))) => {
+          Err(::nom::Err::Error(::nom::simple_errors::Context::Code(&[][..], e)))
+        }
+        Err(::nom::Err::Failure(::nom::simple_errors::Context::Code(_, e))) => {
+          Err(::nom::Err::Failure(::nom::simple_errors::Context::Code(&[][..], e)))
+        }
         Err(::nom::Err::Incomplete(n)) => Err(::nom::Err::Incomplete(n)),
       }
     }
-    ast::CompressionMethod::Lzma => {
-      unimplemented!()
-    }
+    ast::CompressionMethod::Lzma => unimplemented!(),
   }
 }

--- a/rs/src/parsers/shape.rs
+++ b/rs/src/parsers/shape.rs
@@ -1,16 +1,10 @@
-use nom::{IResult as NomResult, Needed};
-use nom::{le_u16 as parse_le_u16, le_u8 as parse_u8};
 use crate::parsers::basic_data_types::{
-  parse_bool_bits,
-  parse_i32_bits,
-  parse_le_fixed8_p8,
-  parse_matrix,
-  parse_s_rgb8,
-  parse_straight_s_rgba8,
-  parse_u16_bits,
-  parse_u32_bits,
+  parse_bool_bits, parse_i32_bits, parse_le_fixed8_p8, parse_matrix, parse_s_rgb8, parse_straight_s_rgba8,
+  parse_u16_bits, parse_u32_bits,
 };
 use crate::parsers::gradient::parse_gradient;
+use nom::{le_u16 as parse_le_u16, le_u8 as parse_u8};
+use nom::{IResult as NomResult, Needed};
 use swf_tree as ast;
 
 #[derive(PartialEq, Eq, Clone, Copy, Ord, PartialOrd)]
@@ -45,15 +39,21 @@ pub fn parse_shape(input: &[u8], version: ShapeVersion) -> NomResult<&[u8], ast:
 pub fn parse_shape_bits(input: (&[u8], usize), version: ShapeVersion) -> NomResult<(&[u8], usize), ast::Shape> {
   do_parse!(
     input,
-    styles: apply!(parse_shape_styles_bits, version) >>
-    records: apply!(parse_shape_record_string_bits, styles.fill_bits, styles.line_bits, version) >>
-    (ast::Shape {
-      initial_styles: ast::ShapeStyles {
-        fill: styles.fill,
-        line: styles.line,
-      },
-      records: records,
-    })
+    styles: apply!(parse_shape_styles_bits, version)
+      >> records:
+        apply!(
+          parse_shape_record_string_bits,
+          styles.fill_bits,
+          styles.line_bits,
+          version
+        )
+      >> (ast::Shape {
+        initial_styles: ast::ShapeStyles {
+          fill: styles.fill,
+          line: styles.line,
+        },
+        records: records,
+      })
   )
 }
 
@@ -68,29 +68,36 @@ pub struct ShapeStyles {
 pub fn parse_shape_styles_bits(input: (&[u8], usize), version: ShapeVersion) -> NomResult<(&[u8], usize), ShapeStyles> {
   do_parse!(
     input,
-    fill: bytes!(apply!(parse_fill_style_list, version)) >>
-    line: bytes!(apply!(parse_line_style_list, version)) >>
-    fill_bits: map!(apply!(parse_u32_bits, 4), |x| x as usize) >>
-    line_bits: map!(apply!(parse_u32_bits, 4), |x| x as usize) >>
-    (ShapeStyles {
-      fill: fill,
-      line: line,
-      fill_bits: fill_bits,
-      line_bits: line_bits,
-    })
+    fill: bytes!(apply!(parse_fill_style_list, version))
+      >> line: bytes!(apply!(parse_line_style_list, version))
+      >> fill_bits: map!(apply!(parse_u32_bits, 4), |x| x as usize)
+      >> line_bits: map!(apply!(parse_u32_bits, 4), |x| x as usize)
+      >> (ShapeStyles {
+        fill: fill,
+        line: line,
+        fill_bits: fill_bits,
+        line_bits: line_bits,
+      })
   )
 }
 
-pub fn parse_shape_record_string_bits(input: (&[u8], usize), mut fill_bits: usize, mut line_bits: usize, version: ShapeVersion) -> NomResult<(&[u8], usize), Vec<ast::ShapeRecord>> {
+pub fn parse_shape_record_string_bits(
+  input: (&[u8], usize),
+  mut fill_bits: usize,
+  mut line_bits: usize,
+  version: ShapeVersion,
+) -> NomResult<(&[u8], usize), Vec<ast::ShapeRecord>> {
   let mut result: Vec<ast::ShapeRecord> = Vec::new();
   let mut current_input = input;
 
   loop {
     match parse_u16_bits(current_input, 6) {
-      Ok((next_input, record_head)) => if record_head == 0 {
-        current_input = next_input;
-        break;
-      },
+      Ok((next_input, record_head)) => {
+        if record_head == 0 {
+          current_input = next_input;
+          break;
+        }
+      }
       Err(::nom::Err::Incomplete(_)) => return Err(::nom::Err::Incomplete(Needed::Unknown)),
       Err(e) => return Err(e),
     };
@@ -116,12 +123,13 @@ pub fn parse_shape_record_string_bits(input: (&[u8], usize), mut fill_bits: usiz
       let (next_input, edge) = if is_straight_edge {
         parse_straight_edge_bits(current_input)?
       } else {
-         parse_curved_edge_bits(current_input)?
+        parse_curved_edge_bits(current_input)?
       };
       current_input = next_input;
       result.push(ast::ShapeRecord::Edge(edge));
     } else {
-      let (next_input, (style_change, style_bits)) = parse_style_change_bits(current_input, fill_bits, line_bits, version)?;
+      let (next_input, (style_change, style_bits)) =
+        parse_style_change_bits(current_input, fill_bits, line_bits, version)?;
       fill_bits = style_bits.0;
       line_bits = style_bits.1;
       result.push(ast::ShapeRecord::StyleChange(style_change));
@@ -132,77 +140,98 @@ pub fn parse_shape_record_string_bits(input: (&[u8], usize), mut fill_bits: usiz
   Ok((current_input, result))
 }
 
-
 pub fn parse_curved_edge_bits(input: (&[u8], usize)) -> NomResult<(&[u8], usize), ast::shape_records::Edge> {
   do_parse!(
     input,
-    n_bits: map!(apply!(parse_u16_bits, 4), |x| (x as usize) + 2) >>
-    control_x: apply!(parse_i32_bits, n_bits) >>
-    control_y: apply!(parse_i32_bits, n_bits) >>
-    anchor_x: apply!(parse_i32_bits, n_bits) >>
-    anchor_y: apply!(parse_i32_bits, n_bits) >>
-    (ast::shape_records::Edge {
-      delta: ast::Vector2D { x: control_x + anchor_x, y: control_y + anchor_y },
-      control_delta: Option::Some(ast::Vector2D {x: control_x, y: control_y}),
-    })
+    n_bits: map!(apply!(parse_u16_bits, 4), |x| (x as usize) + 2)
+      >> control_x: apply!(parse_i32_bits, n_bits)
+      >> control_y: apply!(parse_i32_bits, n_bits)
+      >> anchor_x: apply!(parse_i32_bits, n_bits)
+      >> anchor_y: apply!(parse_i32_bits, n_bits)
+      >> (ast::shape_records::Edge {
+        delta: ast::Vector2D {
+          x: control_x + anchor_x,
+          y: control_y + anchor_y
+        },
+        control_delta: Option::Some(ast::Vector2D {
+          x: control_x,
+          y: control_y
+        }),
+      })
   )
 }
 
 pub fn parse_straight_edge_bits(input: (&[u8], usize)) -> NomResult<(&[u8], usize), ast::shape_records::Edge> {
   do_parse!(
     input,
-    n_bits: map!(apply!(parse_u16_bits, 4), |x| (x as usize) + 2) >>
-    is_diagonal: call!(parse_bool_bits) >>
-    is_vertical: map!(cond!(!is_diagonal, call!(parse_bool_bits)), |opt: Option<bool>| opt.unwrap_or_default()) >>
-    delta_x: cond!(is_diagonal || !is_vertical, apply!(parse_i32_bits, n_bits)) >>
-    delta_y: cond!(is_diagonal || is_vertical, apply!(parse_i32_bits, n_bits)) >>
-    (ast::shape_records::Edge {
-      delta: ast::Vector2D { x: delta_x.unwrap_or_default(), y: delta_y.unwrap_or_default() },
-      control_delta: Option::None,
-    })
+    n_bits: map!(apply!(parse_u16_bits, 4), |x| (x as usize) + 2)
+      >> is_diagonal: call!(parse_bool_bits)
+      >> is_vertical:
+        map!(cond!(!is_diagonal, call!(parse_bool_bits)), |opt: Option<bool>| opt
+          .unwrap_or_default())
+      >> delta_x: cond!(is_diagonal || !is_vertical, apply!(parse_i32_bits, n_bits))
+      >> delta_y: cond!(is_diagonal || is_vertical, apply!(parse_i32_bits, n_bits))
+      >> (ast::shape_records::Edge {
+        delta: ast::Vector2D {
+          x: delta_x.unwrap_or_default(),
+          y: delta_y.unwrap_or_default()
+        },
+        control_delta: Option::None,
+      })
   )
 }
 
-pub fn parse_style_change_bits(input: (&[u8], usize), fill_bits: usize, line_bits: usize, version: ShapeVersion) -> NomResult<(&[u8], usize), (ast::shape_records::StyleChange, (usize, usize))> {
+pub fn parse_style_change_bits(
+  input: (&[u8], usize),
+  fill_bits: usize,
+  line_bits: usize,
+  version: ShapeVersion,
+) -> NomResult<(&[u8], usize), (ast::shape_records::StyleChange, (usize, usize))> {
   do_parse!(
     input,
-    has_new_styles: parse_bool_bits >>
-    change_line_style: parse_bool_bits >>
-    change_right_fill: parse_bool_bits >>
-    change_left_fill: parse_bool_bits >>
-    has_move_to: parse_bool_bits >>
-    move_to: cond!(has_move_to,
-      do_parse!(
-        move_to_bits: apply!(parse_u16_bits, 5) >>
-        x: apply!(parse_i32_bits, move_to_bits as usize) >>
-        y: apply!(parse_i32_bits, move_to_bits as usize) >>
-        (ast::Vector2D {x: x, y: y})
-      )
-    ) >>
-    left_fill: cond!(change_left_fill, apply!(parse_u16_bits, fill_bits)) >>
-    right_fill: cond!(change_right_fill, apply!(parse_u16_bits, fill_bits)) >>
-    line_style: cond!(change_line_style, apply!(parse_u16_bits, line_bits)) >>
-    styles: map!(
-      cond!(has_new_styles, apply!(parse_shape_styles_bits, version)),
-      |styles| match styles {
-        Option::Some(styles) => (
-          Option::Some(ast::ShapeStyles {fill: styles.fill, line: styles.line}),
-          styles.fill_bits,
-          styles.line_bits,
-        ),
-        Option::None => (Option::None, fill_bits, line_bits),
-      }
-    ) >>
-    ((
-      ast::shape_records::StyleChange {
+    has_new_styles: parse_bool_bits
+      >> change_line_style: parse_bool_bits
+      >> change_right_fill: parse_bool_bits
+      >> change_left_fill: parse_bool_bits
+      >> has_move_to: parse_bool_bits
+      >> move_to:
+        cond!(
+          has_move_to,
+          do_parse!(
+            move_to_bits: apply!(parse_u16_bits, 5)
+              >> x: apply!(parse_i32_bits, move_to_bits as usize)
+              >> y: apply!(parse_i32_bits, move_to_bits as usize)
+              >> (ast::Vector2D { x: x, y: y })
+          )
+        )
+      >> left_fill: cond!(change_left_fill, apply!(parse_u16_bits, fill_bits))
+      >> right_fill: cond!(change_right_fill, apply!(parse_u16_bits, fill_bits))
+      >> line_style: cond!(change_line_style, apply!(parse_u16_bits, line_bits))
+      >> styles:
+        map!(
+          cond!(has_new_styles, apply!(parse_shape_styles_bits, version)),
+          |styles| match styles {
+            Option::Some(styles) => (
+              Option::Some(ast::ShapeStyles {
+                fill: styles.fill,
+                line: styles.line
+              }),
+              styles.fill_bits,
+              styles.line_bits,
+            ),
+            Option::None => (Option::None, fill_bits, line_bits),
+          }
+        )
+      >> ((
+        ast::shape_records::StyleChange {
           move_to: move_to,
           left_fill: left_fill.map(|x| x as usize),
           right_fill: right_fill.map(|x| x as usize),
           line_style: line_style.map(|x| x as usize),
           new_styles: styles.0,
-      },
-      (styles.1, styles.2),
-    ))
+        },
+        (styles.1, styles.2),
+      ))
   )
 }
 
@@ -216,7 +245,11 @@ pub fn parse_list_length(input: &[u8], allow_extended: bool) -> NomResult<&[u8],
 }
 
 pub fn parse_fill_style_list(input: &[u8], version: ShapeVersion) -> NomResult<&[u8], Vec<ast::FillStyle>> {
-  length_count!(input, apply!(parse_list_length, version >= ShapeVersion::Shape2), apply!(parse_fill_style, version >= ShapeVersion::Shape3))
+  length_count!(
+    input,
+    apply!(parse_list_length, version >= ShapeVersion::Shape2),
+    apply!(parse_fill_style, version >= ShapeVersion::Shape3)
+  )
 }
 
 pub fn parse_fill_style(input: &[u8], with_alpha: bool) -> NomResult<&[u8], ast::FillStyle> {
@@ -236,63 +269,70 @@ pub fn parse_fill_style(input: &[u8], with_alpha: bool) -> NomResult<&[u8], ast:
 pub fn parse_bitmap_fill(input: &[u8], repeating: bool, smoothed: bool) -> NomResult<&[u8], ast::fill_styles::Bitmap> {
   do_parse!(
     input,
-    bitmap_id: parse_le_u16 >>
-    matrix: parse_matrix >>
-    (ast::fill_styles::Bitmap {
-      bitmap_id: bitmap_id,
-      matrix: matrix,
-      repeating: repeating,
-      smoothed: smoothed
-    })
+    bitmap_id: parse_le_u16
+      >> matrix: parse_matrix
+      >> (ast::fill_styles::Bitmap {
+        bitmap_id: bitmap_id,
+        matrix: matrix,
+        repeating: repeating,
+        smoothed: smoothed
+      })
   )
 }
 
 pub fn parse_focal_gradient_fill(input: &[u8], with_alpha: bool) -> NomResult<&[u8], ast::fill_styles::FocalGradient> {
   do_parse!(
     input,
-    matrix: parse_matrix >>
-    gradient: apply!(parse_gradient, with_alpha) >>
-    focal_point: parse_le_fixed8_p8 >>
-    (ast::fill_styles::FocalGradient {
-      matrix: matrix,
-      gradient: gradient,
-      focal_point: focal_point
-    })
+    matrix: parse_matrix
+      >> gradient: apply!(parse_gradient, with_alpha)
+      >> focal_point: parse_le_fixed8_p8
+      >> (ast::fill_styles::FocalGradient {
+        matrix: matrix,
+        gradient: gradient,
+        focal_point: focal_point
+      })
   )
 }
 
-pub fn parse_linear_gradient_fill(input: &[u8], with_alpha: bool) -> NomResult<&[u8], ast::fill_styles::LinearGradient> {
+pub fn parse_linear_gradient_fill(
+  input: &[u8],
+  with_alpha: bool,
+) -> NomResult<&[u8], ast::fill_styles::LinearGradient> {
   do_parse!(
     input,
-    matrix: parse_matrix >>
-    gradient: apply!(parse_gradient, with_alpha) >>
-    (ast::fill_styles::LinearGradient {
-      matrix: matrix,
-      gradient: gradient
-    })
+    matrix: parse_matrix
+      >> gradient: apply!(parse_gradient, with_alpha)
+      >> (ast::fill_styles::LinearGradient {
+        matrix: matrix,
+        gradient: gradient
+      })
   )
 }
 
-pub fn parse_radial_gradient_fill(input: &[u8], with_alpha: bool) -> NomResult<&[u8], ast::fill_styles::RadialGradient> {
+pub fn parse_radial_gradient_fill(
+  input: &[u8],
+  with_alpha: bool,
+) -> NomResult<&[u8], ast::fill_styles::RadialGradient> {
   do_parse!(
     input,
-    matrix: parse_matrix >>
-    gradient: apply!(parse_gradient, with_alpha) >>
-    (ast::fill_styles::RadialGradient {
-      matrix: matrix,
-      gradient: gradient
-    })
+    matrix: parse_matrix
+      >> gradient: apply!(parse_gradient, with_alpha)
+      >> (ast::fill_styles::RadialGradient {
+        matrix: matrix,
+        gradient: gradient
+      })
   )
 }
 
 pub fn parse_solid_fill(input: &[u8], with_alpha: bool) -> NomResult<&[u8], ast::fill_styles::Solid> {
   do_parse!(
     input,
-    color: switch!(value!(with_alpha),
-      true => call!(parse_straight_s_rgba8) |
-      false => map!(parse_s_rgb8, |c| ast::StraightSRgba8 {r: c.r, g: c.g, b: c.b, a: 255})
-    ) >>
-    (ast::fill_styles::Solid {color: color})
+    color:
+      switch!(value!(with_alpha),
+        true => call!(parse_straight_s_rgba8) |
+        false => map!(parse_s_rgb8, |c| ast::StraightSRgba8 {r: c.r, g: c.g, b: c.b, a: 255})
+      )
+      >> (ast::fill_styles::Solid { color: color })
   )
 }
 
@@ -310,22 +350,23 @@ pub fn parse_line_style_list(input: &[u8], version: ShapeVersion) -> NomResult<&
 pub fn parse_line_style(input: &[u8], with_alpha: bool) -> NomResult<&[u8], ast::LineStyle> {
   do_parse!(
     input,
-    width: parse_le_u16 >>
-    color: switch!(value!(with_alpha),
-      true => call!(parse_straight_s_rgba8) |
-      false => map!(parse_s_rgb8, |c| ast::StraightSRgba8 {r: c.r, g: c.g, b: c.b, a: 255})
-    ) >>
-    (ast::LineStyle {
-      width: width,
-      start_cap: ast::CapStyle::Round,
-      end_cap: ast::CapStyle::Round,
-      join: ast::JoinStyle::Round,
-      no_h_scale: false,
-      no_v_scale: false,
-      no_close: false,
-      pixel_hinting: false,
-      fill: ast::FillStyle::Solid(ast::fill_styles::Solid { color }),
-    })
+    width: parse_le_u16
+      >> color:
+        switch!(value!(with_alpha),
+          true => call!(parse_straight_s_rgba8) |
+          false => map!(parse_s_rgb8, |c| ast::StraightSRgba8 {r: c.r, g: c.g, b: c.b, a: 255})
+        )
+      >> (ast::LineStyle {
+        width: width,
+        start_cap: ast::CapStyle::Round,
+        end_cap: ast::CapStyle::Round,
+        join: ast::JoinStyle::Round,
+        no_h_scale: false,
+        no_v_scale: false,
+        no_close: false,
+        pixel_hinting: false,
+        fill: ast::FillStyle::Solid(ast::fill_styles::Solid { color }),
+      })
   )
 }
 

--- a/rs/src/parsers/sound.rs
+++ b/rs/src/parsers/sound.rs
@@ -1,4 +1,4 @@
-use nom::{IResult as NomResult, le_u16 as parse_le_u16, le_u32 as parse_le_u32, le_u8 as parse_u8};
+use nom::{le_u16 as parse_le_u16, le_u32 as parse_le_u32, le_u8 as parse_u8, IResult as NomResult};
 use swf_tree as ast;
 
 pub fn sound_rate_from_id(sound_rate_id: u8) -> ast::SoundRate {
@@ -63,13 +63,13 @@ pub fn parse_sound_info(input: &[u8]) -> NomResult<&[u8], ast::SoundInfo> {
 pub fn parse_sound_envelope(input: &[u8]) -> NomResult<&[u8], ast::SoundEnvelope> {
   do_parse!(
     input,
-    pos44: parse_le_u32 >>
-    left_level: parse_le_u16 >>
-    right_level: parse_le_u16 >>
-    (ast::SoundEnvelope {
-      pos44,
-      left_level,
-      right_level,
-    })
+    pos44: parse_le_u32
+      >> left_level: parse_le_u16
+      >> right_level: parse_le_u16
+      >> (ast::SoundEnvelope {
+        pos44,
+        left_level,
+        right_level,
+      })
   )
 }

--- a/rs/src/parsers/text.rs
+++ b/rs/src/parsers/text.rs
@@ -1,15 +1,10 @@
-use swf_tree as ast;
-use nom::IResult;
-use nom::{le_i16 as parse_le_i16, le_u8 as parse_u8, le_u16 as parse_le_u16, le_u32 as parse_le_u32};
 use crate::parsers::basic_data_types::{
-  parse_rect,
-  parse_le_f16,
-  parse_s_rgb8,
-  parse_straight_s_rgba8,
-  parse_i32_bits,
-  parse_u32_bits,
+  parse_i32_bits, parse_le_f16, parse_rect, parse_s_rgb8, parse_straight_s_rgba8, parse_u32_bits,
 };
 use crate::parsers::shape::parse_glyph;
+use nom::IResult;
+use nom::{le_i16 as parse_le_i16, le_u16 as parse_le_u16, le_u32 as parse_le_u32, le_u8 as parse_u8};
+use swf_tree as ast;
 
 #[derive(PartialEq, Eq, Clone, Copy, Ord, PartialOrd)]
 pub enum FontVersion {
@@ -54,29 +49,29 @@ pub fn parse_text_renderer_bits(input: (&[u8], usize)) -> IResult<(&[u8], usize)
 pub fn parse_font_alignment_zone(input: &[u8]) -> IResult<&[u8], ast::text::FontAlignmentZone> {
   do_parse!(
     input,
-    data: length_count!(parse_u8, parse_font_alignment_zone_data) >>
-    flags: parse_u8 >>
-    (ast::text::FontAlignmentZone {
-      data: data,
-      has_x: (flags & (1 << 0)) != 0,
-      has_y: (flags & (1 << 1)) != 0
-    })
+    data: length_count!(parse_u8, parse_font_alignment_zone_data)
+      >> flags: parse_u8
+      >> (ast::text::FontAlignmentZone {
+        data: data,
+        has_x: (flags & (1 << 0)) != 0,
+        has_y: (flags & (1 << 1)) != 0
+      })
   )
 }
 
 pub fn parse_font_alignment_zone_data(input: &[u8]) -> IResult<&[u8], ast::text::FontAlignmentZoneData> {
   do_parse!(
     input,
-    origin: parse_le_f16 >>
-    size: parse_le_f16 >>
-    (ast::text::FontAlignmentZoneData {
-      origin,
-      size,
-    })
+    origin: parse_le_f16 >> size: parse_le_f16 >> (ast::text::FontAlignmentZoneData { origin, size })
   )
 }
 
-pub fn parse_text_record_string(input: &[u8], has_alpha: bool, index_bits: usize, advance_bits: usize) -> IResult<&[u8], Vec<ast::text::TextRecord>> {
+pub fn parse_text_record_string(
+  input: &[u8],
+  has_alpha: bool,
+  index_bits: usize,
+  advance_bits: usize,
+) -> IResult<&[u8], Vec<ast::text::TextRecord>> {
   let mut result: Vec<ast::text::TextRecord> = Vec::new();
   let mut current_input: &[u8] = input;
   while current_input.len() > 0 {
@@ -97,7 +92,12 @@ pub fn parse_text_record_string(input: &[u8], has_alpha: bool, index_bits: usize
   Err(::nom::Err::Incomplete(::nom::Needed::Unknown))
 }
 
-pub fn parse_text_record(input: &[u8], has_alpha: bool, index_bits: usize, advance_bits: usize) -> IResult<&[u8], ast::text::TextRecord> {
+pub fn parse_text_record(
+  input: &[u8],
+  has_alpha: bool,
+  index_bits: usize,
+  advance_bits: usize,
+) -> IResult<&[u8], ast::text::TextRecord> {
   do_parse!(
     input,
     flags: parse_u8 >>
@@ -127,26 +127,40 @@ pub fn parse_text_record(input: &[u8], has_alpha: bool, index_bits: usize, advan
   )
 }
 
-pub fn parse_glyph_entries(input: (&[u8], usize), entry_count: u8, index_bits: usize, advance_bits: usize) -> IResult<(&[u8], usize), Vec<ast::text::GlyphEntry>> {
-  length_count!(input,
+pub fn parse_glyph_entries(
+  input: (&[u8], usize),
+  entry_count: u8,
+  index_bits: usize,
+  advance_bits: usize,
+) -> IResult<(&[u8], usize), Vec<ast::text::GlyphEntry>> {
+  length_count!(
+    input,
     value!(entry_count),
     apply!(parse_glyph_entry, index_bits, advance_bits)
   )
 }
 
-pub fn parse_glyph_entry(input: (&[u8], usize), index_bits: usize, advance_bits: usize) -> IResult<(&[u8], usize), ast::text::GlyphEntry> {
+pub fn parse_glyph_entry(
+  input: (&[u8], usize),
+  index_bits: usize,
+  advance_bits: usize,
+) -> IResult<(&[u8], usize), ast::text::GlyphEntry> {
   do_parse!(
     input,
-    index: map!(apply!(parse_u32_bits, index_bits), |x| x as usize) >>
-    advance: apply!(parse_i32_bits, advance_bits) >>
-    (ast::text::GlyphEntry {
-      index: index,
-      advance: advance,
-    })
+    index: map!(apply!(parse_u32_bits, index_bits), |x| x as usize)
+      >> advance: apply!(parse_i32_bits, advance_bits)
+      >> (ast::text::GlyphEntry {
+        index: index,
+        advance: advance,
+      })
   )
 }
 
-pub fn parse_offset_glyphs(input: &[u8], glyph_count: usize, use_wide_offsets: bool) -> IResult<&[u8], Vec<ast::Glyph>> {
+pub fn parse_offset_glyphs(
+  input: &[u8],
+  glyph_count: usize,
+  use_wide_offsets: bool,
+) -> IResult<&[u8], Vec<ast::Glyph>> {
   let parsed_offsets = if use_wide_offsets {
     pair!(
       input,
@@ -167,7 +181,11 @@ pub fn parse_offset_glyphs(input: &[u8], glyph_count: usize, use_wide_offsets: b
   let mut glyphs: Vec<ast::Glyph> = Vec::with_capacity(glyph_count);
   for i in 0..glyph_count {
     let start_offset = offsets[i];
-    let end_offset = if i + 1 < glyph_count { offsets[i + 1] } else { end_offset };
+    let end_offset = if i + 1 < glyph_count {
+      offsets[i + 1]
+    } else {
+      end_offset
+    };
     match parse_glyph(&input[start_offset..end_offset]) {
       Ok((_, o)) => glyphs.push(o),
       Err(e) => return Err(e),
@@ -179,33 +197,34 @@ pub fn parse_offset_glyphs(input: &[u8], glyph_count: usize, use_wide_offsets: b
 pub fn parse_kerning_record(input: &[u8]) -> IResult<&[u8], ast::text::KerningRecord> {
   do_parse!(
     input,
-    left: parse_le_u16 >>
-    right: parse_le_u16 >>
-    adjustment: parse_le_i16 >>
-    (ast::text::KerningRecord {
-      left: left,
-      right: right,
-      adjustment: adjustment,
-    })
+    left: parse_le_u16
+      >> right: parse_le_u16
+      >> adjustment: parse_le_i16
+      >> (ast::text::KerningRecord {
+        left: left,
+        right: right,
+        adjustment: adjustment,
+      })
   )
 }
 
 pub fn parse_font_layout(input: &[u8], glyph_count: usize) -> IResult<&[u8], ast::text::FontLayout> {
-  do_parse!(input,
-    ascent: parse_le_u16 >>
-    descent: parse_le_u16 >>
-    leading: parse_le_u16 >>
-    advances: length_count!(value!(glyph_count), parse_le_u16) >>
-    bounds: length_count!(value!(glyph_count), parse_rect) >>
-    kerning: length_count!(parse_le_u16, parse_kerning_record) >>
-    (ast::text::FontLayout {
-      ascent: ascent,
-      descent: descent,
-      leading: leading,
-      advances,
-      bounds,
-      kerning,
-    })
+  do_parse!(
+    input,
+    ascent: parse_le_u16
+      >> descent: parse_le_u16
+      >> leading: parse_le_u16
+      >> advances: length_count!(value!(glyph_count), parse_le_u16)
+      >> bounds: length_count!(value!(glyph_count), parse_rect)
+      >> kerning: length_count!(parse_le_u16, parse_kerning_record)
+      >> (ast::text::FontLayout {
+        ascent: ascent,
+        descent: descent,
+        leading: leading,
+        advances,
+        bounds,
+        kerning,
+      })
   )
 }
 

--- a/rs/src/state.rs
+++ b/rs/src/state.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 #[derive(Debug)]
 pub struct ParseState {
   swf_version: u8,
-  glyph_counts: HashMap<usize, usize>
+  glyph_counts: HashMap<usize, usize>,
 }
 
 impl ParseState {


### PR DESCRIPTION
Hello!

I added rustfmt to the project, customizing the indentation to be 2 spaces. I believe you'd also prefer binop_separator = "Back" (see https://rust-lang.github.io/rustfmt/#binop_separator), but as its still unstable, I left it commented out....

Contributes to issue #25, I was going to also add clippy, but some lints are related to code generated inside nom macros! and as you'll probably have to update nom to 5.0 eventually (which is focused on function instead of macros) I decided to wait...

Also, I ran rustfmt in your name as you're the actual author of those lines...

To format your code just install rustfmt with:
```
rustup component add rustfmt
```
And to run its as simple as:
```
cargo fmt
```

Thanks for this amazing project 😉 