### PR TITLE
[rs] Remove `nom` macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Next
+
+### Rust
+
+- **[Fix]** Remove `nom` macros.
+
 # 0.9.0 (2019-10-17)
 
 - **[Breaking change]** Update to `swf-tree@0.9`.

--- a/rs/src/lib.rs
+++ b/rs/src/lib.rs
@@ -1,5 +1,4 @@
 extern crate inflate;
-#[macro_use]
 extern crate nom;
 extern crate num_traits;
 extern crate swf_fixed;

--- a/rs/src/parsers/button.rs
+++ b/rs/src/parsers/button.rs
@@ -1,10 +1,9 @@
-use nom::number::streaming::{le_u16 as parse_le_u16, le_u8 as parse_u8};
-use nom::IResult as NomResult;
-use swf_tree as ast;
-
 use crate::parsers::basic_data_types::{parse_color_transform_with_alpha, parse_matrix};
 use crate::parsers::display::{parse_blend_mode, parse_filter_list};
 use crate::parsers::sound::parse_sound_info;
+use nom::number::streaming::{le_u16 as parse_le_u16, le_u8 as parse_u8};
+use nom::IResult as NomResult;
+use swf_tree as ast;
 
 #[derive(PartialEq, Eq, Clone, Copy, Ord, PartialOrd)]
 pub enum ButtonVersion {
@@ -129,32 +128,33 @@ pub fn parse_button_cond(input: &[u8]) -> NomResult<&[u8], ast::ButtonCond> {
     }
   }
 
-  do_parse!(
+  let (input, flags) = parse_le_u16(input)?;
+  let idle_to_over_up = (flags & (1 << 0)) != 0;
+  let over_up_to_idle = (flags & (1 << 1)) != 0;
+  let over_up_to_over_down = (flags & (1 << 2)) != 0;
+  let over_down_to_over_up = (flags & (1 << 3)) != 0;
+  let over_down_to_out_down = (flags & (1 << 4)) != 0;
+  let out_down_to_over_down = (flags & (1 << 5)) != 0;
+  let out_down_to_idle = (flags & (1 << 6)) != 0;
+  let idle_to_over_down = (flags & (1 << 7)) != 0;
+  let over_down_to_idle = (flags & (1 << 8)) != 0;
+  let key_press = key_press_from_id((flags >> 9) & 0x7f);
+
+  Ok((
     input,
-    flags: parse_le_u16
-      >> idle_to_over_up: value!((flags & (1 << 0)) != 0)
-      >> over_up_to_idle: value!((flags & (1 << 1)) != 0)
-      >> over_up_to_over_down: value!((flags & (1 << 2)) != 0)
-      >> over_down_to_over_up: value!((flags & (1 << 3)) != 0)
-      >> over_down_to_out_down: value!((flags & (1 << 4)) != 0)
-      >> out_down_to_over_down: value!((flags & (1 << 5)) != 0)
-      >> out_down_to_idle: value!((flags & (1 << 6)) != 0)
-      >> idle_to_over_down: value!((flags & (1 << 7)) != 0)
-      >> over_down_to_idle: value!((flags & (1 << 8)) != 0)
-      >> key_press: map!(value!((flags >> 9) & 0x7f), key_press_from_id)
-      >> (ast::ButtonCond {
-        key_press,
-        over_down_to_idle,
-        idle_to_over_up,
-        over_up_to_idle,
-        over_up_to_over_down,
-        over_down_to_over_up,
-        over_down_to_out_down,
-        out_down_to_over_down,
-        out_down_to_idle,
-        idle_to_over_down,
-      })
-  )
+    ast::ButtonCond {
+      key_press,
+      over_down_to_idle,
+      idle_to_over_up,
+      over_up_to_idle,
+      over_up_to_over_down,
+      over_down_to_over_up,
+      over_down_to_out_down,
+      out_down_to_over_down,
+      out_down_to_idle,
+      idle_to_over_down,
+    },
+  ))
 }
 
 pub fn parse_button_sound(input: &[u8]) -> NomResult<&[u8], Option<ast::ButtonSound>> {

--- a/rs/src/parsers/header.rs
+++ b/rs/src/parsers/header.rs
@@ -1,45 +1,52 @@
-use crate::parsers::basic_data_types::{parse_le_ufixed8_p8, parse_rect};
 use nom::number::streaming::{le_u16 as parse_le_u16, le_u32 as parse_le_u32, le_u8 as parse_u8};
 use nom::IResult;
+use std::convert::TryFrom;
 use swf_tree as ast;
 
+use crate::parsers::basic_data_types::{parse_le_ufixed8_p8, parse_rect};
+
 pub fn parse_compression_method(input: &[u8]) -> IResult<&[u8], ast::CompressionMethod> {
-  alt!(
-    input,
-    tag!("FWS") => {|_| ast::CompressionMethod::None}
-  | tag!("CWS") => {|_| ast::CompressionMethod::Deflate}
-  | tag!("ZWS") => {|_| ast::CompressionMethod::Lzma}
-  // TODO(demurgos): Throw error if none matches
-  )
+  use nom::bytes::streaming::take;
+  let (input, tag) = take(3usize)(input)?;
+  match tag {
+    b"FWS" => Ok((input, ast::CompressionMethod::None)),
+    b"CWS" => Ok((input, ast::CompressionMethod::Deflate)),
+    b"ZWS" => Ok((input, ast::CompressionMethod::Lzma)),
+    _ => return Err(nom::Err::Error((input, nom::error::ErrorKind::Switch))),
+  }
 }
 
 pub fn parse_swf_signature(input: &[u8]) -> IResult<&[u8], ast::SwfSignature> {
-  do_parse!(
+  use nom::combinator::map;
+
+  let (input, compression_method) = parse_compression_method(input)?;
+  let (input, swf_version) = parse_u8(input)?;
+  let (input, uncompressed_file_length) = map(parse_le_u32, |x| usize::try_from(x).unwrap())(input)?;
+
+  Ok((
     input,
-    compression_method: parse_compression_method
-      >> swf_version: parse_u8
-      >> uncompressed_file_length: map!(parse_le_u32, |x| x as usize)
-      >> (ast::SwfSignature {
-        compression_method: compression_method,
-        swf_version: swf_version,
-        uncompressed_file_length: uncompressed_file_length,
-      })
-  )
+    ast::SwfSignature {
+      compression_method,
+      swf_version,
+      uncompressed_file_length,
+    },
+  ))
 }
 
 pub fn parse_header(input: &[u8], swf_version: u8) -> IResult<&[u8], ast::Header> {
-  do_parse!(
+  let (input, frame_size) = parse_rect(input)?;
+  let (input, frame_rate) = parse_le_ufixed8_p8(input)?;
+  let (input, frame_count) = parse_le_u16(input)?;
+
+  Ok((
     input,
-    frame_size: parse_rect
-      >> frame_rate: parse_le_ufixed8_p8
-      >> frame_count: parse_le_u16
-      >> (ast::Header {
-        swf_version: swf_version,
-        frame_size: frame_size,
-        frame_rate: frame_rate,
-        frame_count: frame_count,
-      })
-  )
+    ast::Header {
+      swf_version,
+      frame_size,
+      frame_rate,
+      frame_count,
+    },
+  ))
 }
 
 #[cfg(test)]

--- a/rs/src/parsers/sound.rs
+++ b/rs/src/parsers/sound.rs
@@ -36,41 +36,51 @@ pub fn is_uncompressed_audio_coding_format(format: &ast::AudioCodingFormat) -> b
 }
 
 pub fn parse_sound_info(input: &[u8]) -> NomResult<&[u8], ast::SoundInfo> {
-  do_parse!(
+  use nom::combinator::cond;
+  use nom::multi::count;
+
+  let (input, flags) = parse_u8(input)?;
+  let has_in_point = (flags & (1 << 0)) != 0;
+  let has_out_point = (flags & (1 << 1)) != 0;
+  let has_loops = (flags & (1 << 2)) != 0;
+  let has_envelope = (flags & (1 << 3)) != 0;
+  let sync_no_multiple = (flags & (1 << 4)) != 0;
+  let sync_stop = (flags & (1 << 5)) != 0;
+  // Bits [6, 7] are reserved
+  let (input, in_point) = cond(has_in_point, parse_le_u32)(input)?;
+  let (input, out_point) = cond(has_out_point, parse_le_u32)(input)?;
+  let (input, loop_count) = cond(has_loops, parse_le_u16)(input)?;
+  let (input, envelope_records) = if has_envelope {
+    let (input, record_count) = parse_u8(input)?;
+    let (input, envelope_records) = count(parse_sound_envelope, usize::from(record_count))(input)?;
+    (input, Some(envelope_records))
+  } else {
+    (input, None)
+  };
+
+  Ok((
     input,
-    flags: parse_u8 >>
-    has_in_point: value!((flags & (1 << 0)) != 0) >>
-    has_out_point: value!((flags & (1 << 1)) != 0) >>
-    has_loops: value!((flags & (1 << 2)) != 0) >>
-    has_envelope: value!((flags & (1 << 3)) != 0) >>
-    sync_no_multiple: value!((flags & (1 << 4)) != 0) >>
-    sync_stop: value!((flags & (1 << 5)) != 0) >>
-    // Bits [6, 7] are reserved
-    in_point: cond!(has_in_point, parse_le_u32) >>
-    out_point: cond!(has_out_point, parse_le_u32) >>
-    loop_count: cond!(has_loops, parse_le_u16) >>
-    envelope_records: cond!(has_envelope, length_count!(parse_u8, parse_sound_envelope)) >>
-    (ast::SoundInfo {
+    ast::SoundInfo {
       sync_stop,
       sync_no_multiple,
       in_point,
       out_point,
       loop_count,
       envelope_records,
-    })
-  )
+    },
+  ))
 }
 
 pub fn parse_sound_envelope(input: &[u8]) -> NomResult<&[u8], ast::SoundEnvelope> {
-  do_parse!(
+  let (input, pos44) = parse_le_u32(input)?;
+  let (input, left_level) = parse_le_u16(input)?;
+  let (input, right_level) = parse_le_u16(input)?;
+  Ok((
     input,
-    pos44: parse_le_u32
-      >> left_level: parse_le_u16
-      >> right_level: parse_le_u16
-      >> (ast::SoundEnvelope {
-        pos44,
-        left_level,
-        right_level,
-      })
-  )
+    ast::SoundEnvelope {
+      pos44,
+      left_level,
+      right_level,
+    },
+  ))
 }


### PR DESCRIPTION
This commit completes the migration to `nom@5` by removing all its macros, in favor of functions.