### PR TITLE
[ts] Fix pre-release npm tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,15 @@
 - **[Breaking change]** Make the parsers stateless by parsing font alignment zones based on available input instead of memorized glyph count.
 - **[Feature]** Add invalid tag error recovery.
 
-### Rust
+## Rust
 
 - **[Feature]** Add experimental streaming parser.
 - **[Fix]** Remove `nom` macros.
 - **[Fix]** Add `clippy` support.
+
+## Typescript
+
+- **[Fix]** Fix pre-release npm tag.
 
 # 0.9.0 (2019-10-17)
 

--- a/ts/gulpfile.ts
+++ b/ts/gulpfile.ts
@@ -42,7 +42,7 @@ const lib: LibTarget = {
       return <any> {...old, version, scripts: undefined, private: false};
     },
     npmPublish: {
-      tag: options.devDist !== undefined ? "next" : "latest",
+      tag: options.next !== undefined ? "next" : "latest",
     },
   },
   customTypingsDir: "src/custom-typings",


### PR DESCRIPTION
This commit fixes the pre-release npm tag. Instead of being published with the `next` tag, pre-releases used the default `latest` tag.