### PR TITLE
[ts] Add support for invalid tag body

### DIFF
--- a/rs/src/streaming/tag.rs
+++ b/rs/src/streaming/tag.rs
@@ -24,7 +24,6 @@ pub(crate) enum StreamingTagError {
 
 /// Parses the tag at the start of the (possibly incomplete) input.
 ///
-/// The minimum length of `input` for a tag is `1`.
 /// In case of success, returns the remaining input and `Tag`.
 /// In case of error, returns the original input and error description.
 pub(crate) fn parse_tag(input: &[u8], swf_version: u8) -> Result<(&[u8], Option<ast::Tag>), StreamingTagError> {
@@ -36,9 +35,12 @@ pub(crate) fn parse_tag(input: &[u8], swf_version: u8) -> Result<(&[u8], Option<
     Ok(ok) => ok,
     Err(_) => return Err(StreamingTagError::IncompleteHeader),
   };
+
+  // `EndOfTags`
   if header.code == 0 {
     return Ok((&[], None));
   }
+
   let body_len = usize::try_from(header.length).unwrap();
   if input.len() < body_len {
     let header_len = base_input.len() - input.len();

--- a/ts/src/lib/errors/incomplete-tag-header.ts
+++ b/ts/src/lib/errors/incomplete-tag-header.ts
@@ -1,0 +1,18 @@
+import { Incident } from "incident";
+
+export type Name = "IncompleteTagHeader";
+export const name: Name = "IncompleteTagHeader";
+
+export interface Data {
+}
+
+export type Cause = undefined;
+export type IncompleteTagHeaderError = Incident<Data, Name, Cause>;
+
+export function format(_: Data) {
+  return "Failed to parse tag header: Not enough data";
+}
+
+export function createIncompleteTagHeaderError(): IncompleteTagHeaderError {
+  return new Incident(name, {}, format);
+}

--- a/ts/src/lib/errors/incomplete-tag.ts
+++ b/ts/src/lib/errors/incomplete-tag.ts
@@ -1,0 +1,20 @@
+import { Incident } from "incident";
+
+export type Name = "IncompleteTag";
+export const name: Name = "IncompleteTag";
+
+export interface Data {
+  available: number;
+  needed: number;
+}
+
+export type Cause = undefined;
+export type IncompleteTagError = Incident<Data, Name, Cause>;
+
+export function format({needed, available}: Data) {
+  return `Failed to parse tag: Not enough data: ${available} / ${needed} bytes`;
+}
+
+export function createIncompleteTagError(available: number, needed: number): IncompleteTagError {
+  return new Incident(name, {available, needed}, format);
+}

--- a/ts/src/test/tags.spec.ts
+++ b/ts/src/test/tags.spec.ts
@@ -19,30 +19,8 @@ const JSON_VALUE_WRITER: JsonValueWriter = new JsonValueWriter();
 // `BLACKLIST` can be used to forcefully skip some tests.
 const BLACKLIST: ReadonlySet<string> = new Set([
   // "define-shape/shape1-squares",
-  "raw-body/empty-clip-actions-string",
-  "raw-body/incomplete-bitmap",
-  "raw-body/incomplete-bits-lossless",
-  "raw-body/invalid-button-cond-action-string",
-  "raw-body/invalid-cap-style",
-  "raw-body/invalid-csm-text-settings",
-  "raw-body/invalid-define-bits-jpeg2-type",
   "raw-body/invalid-define-font-offset",
-  "raw-body/invalid-define-font2-offset",
-  "raw-body/invalid-define-text-index-bits-and-advance-bits",
-  "raw-body/invalid-gif-header",
-  "raw-body/invalid-gradient-flags",
-  "raw-body/invalid-image-data-size",
-  "raw-body/invalid-jpeg-data",
-  "raw-body/invalid-key-press-code",
-  "raw-body/invalid-morph-gradient",
-  "raw-body/invalid-video-deblocking",
-  "raw-body/jpeg-soi-only",
-  "raw-body/missing-morph-shape-end-record",
   "raw-body/non-utf8-string",
-  "raw-body/unknown-audio-codec",
-  "raw-body/unknown-grid-fitting",
-  "raw-body/unknown-tag-code-and-empty-body",
-  "raw-body/unmatched-morph-shape-record-pair",
 ]);
 // `WHITELIST` can be used to only enable a few tests.
 const WHITELIST: ReadonlySet<string> = new Set([


### PR DESCRIPTION
This commit updates the TS error recovery mechanism to align it with the Typescript implementation: unknown codes and invalid tag bodies now produce a `RawBody` tag.