### PR TITLE
[ts] Detect invalid `DefineGlyphFont` offsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 
 - **[Fix]** Fix pre-release npm tag.
 - **[Fix]** Detect invalid UTF-8.
+- **[Fix]** Detect invalid `DefineGlyphFont` offsets.
 
 # 0.9.0 (2019-10-17)
 

--- a/ts/src/test/tags.spec.ts
+++ b/ts/src/test/tags.spec.ts
@@ -19,7 +19,7 @@ const JSON_VALUE_WRITER: JsonValueWriter = new JsonValueWriter();
 // `BLACKLIST` can be used to forcefully skip some tests.
 const BLACKLIST: ReadonlySet<string> = new Set([
   // "define-shape/shape1-squares",
-  "raw-body/invalid-define-font-offset",
+  // "raw-body/invalid-define-font-offset",
   // "raw-body/non-utf8-string",
 ]);
 // `WHITELIST` can be used to only enable a few tests.


### PR DESCRIPTION
This commit ports the `DefineGlyphFont` offset check from Rust to Typescript.