### PR TITLE
[all] Refactor consumer API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next
 
+- **[Breaking change]** Refactor consumer API. The library now exports a function named
+  `parseSwf` (TS) or `parse_swf` (Rust) at its root ([#11](https://github.com/open-flash/swf-parser/issues/11)).
 - **[Breaking change]** Update to `swf-types@0.10` (new `swf-tree`).
 - **[Breaking change]** Make the parsers stateless by parsing font alignment zones based on available input instead of memorized glyph count.
 - **[Feature]** Add invalid tag error recovery.

--- a/rs/README.md
+++ b/rs/README.md
@@ -15,13 +15,12 @@ Converts bytes to [`swf-types` movies][swf-types].
 ## Usage
 
 ```rust
-use swf_parser;
-use swf_types;
+use swf_parser::parse_swf;
+use swf_types::Movie;
 
 fn main() {
-  let bytes: &[u8] = ...;
-  let (_, movie): (_, swf_types::Movie) = swf_parser::complete::parse_movie(&bytes[..])
-    .expect("Failed to parse movie");
+  let swf_bytes: Vec<u8> = ::std::fs::read("movie.swf").expect("Failed to read movie");
+  let movie: Movie = parse_swf(&swf_bytes).expect("Failed to parse SWF");
 }
 ```
 

--- a/rs/src/complete/tag.rs
+++ b/rs/src/complete/tag.rs
@@ -32,7 +32,7 @@ use swf_types as ast;
 use swf_types::text::FontAlignmentZone;
 use swf_types::{ButtonCondAction, Glyph};
 
-/// Parses that tag at the start of `input`.
+/// Parses the tag at the start of `input`.
 ///
 /// This parser assumes that `input` is complete: it has all the data until the end of the movie.
 ///

--- a/rs/src/lib.rs
+++ b/rs/src/lib.rs
@@ -1,12 +1,14 @@
-pub mod parsers {}
 pub mod complete;
 mod stream_buffer;
 pub mod streaming;
 pub use swf_types;
 
+pub use complete::tag::parse_tag;
+pub use complete::{parse_swf, SwfParseError};
+
 #[cfg(test)]
 mod tests {
-  use crate::complete::parse_swf;
+  use crate::parse_swf;
   use ::swf_types::Movie;
   use ::test_generator::test_resources;
   use nom::IResult as NomResult;

--- a/ts/README.md
+++ b/ts/README.md
@@ -17,12 +17,11 @@ Converts bytes to [`swf-types` movies][swf-types].
 ```typescript
 import fs from "fs";
 import { Movie } from "swf-types/movie";
-import { movieFromBytes } from "swf-parser";
+import { parseSwf } from "swf-parser";
 
 function main(): void {
   const bytes: Uint8Array = fs.readFileSync("movie.swf");
-  const movie: Movie = movieFromBytes(bytes);
-  console.log(`Successfully parsed movie, tag count: ${movie.tags.length}`);
+  const movie: Movie = parseSwf(bytes);
 }
 
 main();

--- a/ts/src/lib/index.ts
+++ b/ts/src/lib/index.ts
@@ -1,10 +1,32 @@
 import { ReadableStream } from "@open-flash/stream";
+import { Uint8 } from "semantic-types";
 import * as swf from "swf-types";
-import { parseMovie } from "./parsers/movie";
+import { parseSwf as parseSwfStream } from "./parsers/movie";
+import { parseTag as parseTagStream } from "./parsers/tags";
 
 export { swf };
 
-export function movieFromBytes(bytes: Uint8Array): swf.Movie {
+/**
+ * Parses a completely loaded SWF file.
+ *
+ * @param bytes SWF file to parse
+ * @returns The parsed Movie
+ */
+export function parseSwf(bytes: Uint8Array): swf.Movie {
   const byteStream: ReadableStream = new ReadableStream(bytes);
-  return parseMovie(byteStream);
+  return parseSwfStream(byteStream);
+}
+
+/**
+ * Parses the tag at the start of `input`.
+ *
+ * This parser assumes that `input` is complete: it has all the data until the end of the movie.
+ *
+ * @param bytes Tag to parse
+ * @param swfVersion SWF version to use for tags depending on the SWF version
+ * @returns The parsed tag, or `undefined` if an error occurred.
+ */
+export function parseTag(bytes: Uint8Array, swfVersion: Uint8): swf.Tag | undefined {
+  const byteStream: ReadableStream = new ReadableStream(bytes);
+  return parseTagStream(byteStream, swfVersion);
 }

--- a/ts/src/lib/parsers/movie.ts
+++ b/ts/src/lib/parsers/movie.ts
@@ -6,16 +6,21 @@ import { CompressionMethod, Header, Movie, SwfSignature, Tag } from "swf-types";
 import { parseHeader, parseSwfSignature } from "./header";
 import { parseTagBlockString } from "./tags";
 
-export function parseMovie(byteStream: ReadableStream): Movie {
+/**
+ * Parses a completely loaded SWF file.
+ *
+ * @param byteStream SWF stream to parse
+ */
+export function parseSwf(byteStream: ReadableStream): Movie {
   const signature: SwfSignature = parseSwfSignature(byteStream);
   switch (signature.compressionMethod) {
     case CompressionMethod.None:
-      return parsePayload(byteStream, signature.swfVersion);
+      return parseMovie(byteStream, signature.swfVersion);
     case CompressionMethod.Deflate:
       const tail: Uint8Array = byteStream.tailBytes();
       const payload: Uint8Array = inflate(tail);
       const payloadStream: ReadableStream = new ReadableStream(payload);
-      return parsePayload(payloadStream, signature.swfVersion);
+      return parseMovie(payloadStream, signature.swfVersion);
     case CompressionMethod.Lzma:
       throw new Incident("NotImplemented", "Support for LZMA compression is not implemented yet");
     default:
@@ -23,7 +28,15 @@ export function parseMovie(byteStream: ReadableStream): Movie {
   }
 }
 
-export function parsePayload(byteStream: ReadableStream, swfVersion: Uint8): Movie {
+/**
+ * Parses a completely loaded movie.
+ *
+ * The movie is the uncompressed payload of the SWF.
+ *
+ * @param byteStream Movie bytestream
+ * @param swfVersion Parsed movie.
+ */
+export function parseMovie(byteStream: ReadableStream, swfVersion: Uint8): Movie {
   const header: Header = parseHeader(byteStream, swfVersion);
   const tags: Tag[] = parseTagBlockString(byteStream, swfVersion);
   return {header, tags};

--- a/ts/src/test/movies.spec.ts
+++ b/ts/src/test/movies.spec.ts
@@ -4,7 +4,7 @@ import { JsonReader } from "kryo/readers/json";
 import { JsonValueWriter } from "kryo/writers/json-value";
 import sysPath from "path";
 import { $Movie, Movie } from "swf-types/movie";
-import { movieFromBytes } from "../lib";
+import { parseSwf } from "../lib";
 import meta from "./meta.js";
 import { readFile, readTextFile, writeTextFile } from "./utils";
 
@@ -27,7 +27,7 @@ describe("movies", function () {
   for (const sample of getSamples()) {
     it(sample.name, async function () {
       const inputBytes: Buffer = await readFile(sample.moviePath);
-      const actualMovie: Movie = movieFromBytes(inputBytes);
+      const actualMovie: Movie = parseSwf(inputBytes);
       const testErr: Error | undefined = $Movie.testError!(actualMovie);
       try {
         chai.assert.isUndefined(testErr, "InvalidMovie");


### PR DESCRIPTION
The library now exports a function named `parseSwf` (TS) or `parse_swf` (Rust) at its root. This commit also normalizes the naming convention around "SWF", "Payload" and "Movie" based on the model documented on the Open Flash website.

Closes open-flash/swf-parser#11