### PR TITLE
[all] Release v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Next
+# 0.12.0 (2020-09-05)
 
 - **[Breaking change]** Update to `swf-types@0.12`.
 

--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -226,7 +226,7 @@ dependencies = [
 
 [[package]]
 name = "swf-parser"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "half",
  "inflate",

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swf-parser"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Charles Samborski <demurgos@demurgos.net>"]
 description = "SWF parser"
 documentation = "https://github.com/open-flash/swf-parser"

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swf-parser",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "SWF parser",
   "licenses": [
     {


### PR DESCRIPTION
- **[Breaking change]** Update to `swf-types@0.12`.

## Rust

- **[Fix]** Don't enable `use-serde` feature from `swf-types` by default.

## Typescript

- **[Breaking change]** Update to native ESM.
- **[Internal]** Switch from `tslint` to `eslint`.