### PR TITLE
[rs] Avoid panic on missing feature

### DIFF
--- a/rs/src/streaming/decompress.rs
+++ b/rs/src/streaming/decompress.rs
@@ -9,17 +9,27 @@ pub(crate) fn decompress_none(bytes: &[u8]) -> Result<Output<'_>, Box<dyn Error>
   Ok((&[][..], bytes.into()))
 }
 
-#[cfg(feature="deflate")]
-pub(crate) fn decompress_zlib(bytes: &[u8]) ->Result<Output<'_>, Box<dyn Error>> {
+#[cfg(feature = "deflate")]
+pub(crate) fn decompress_zlib(bytes: &[u8]) -> Result<Output<'_>, Box<dyn Error>> {
   let out = inflate::inflate_bytes_zlib(bytes).map_err(|msg| {
     Box::<dyn Error>::from(msg)
   })?;
   Ok((&[][..], out.into()))
 }
 
-#[cfg(feature="lzma")]
+#[cfg(not(feature = "deflate"))]
+pub(crate) fn decompress_zlib(_bytes: &[u8]) -> Result<Output<'_>, Box<dyn Error>> {
+  Err(Box::<dyn Error>::from("unsupported SWF compression method `Deflate`: compile `swf-parser` with the `deflate` feature"))
+}
+
+#[cfg(feature = "lzma")]
 pub(crate) fn decompress_lzma(mut bytes: &[u8]) -> Result<Output<'_>, Box<dyn Error>> {
   let mut out = Vec::new();
   lzma_rs::lzma_decompress(&mut bytes, &mut out).map_err(Box::new)?;
   Ok((bytes, out.into()))
+}
+
+#[cfg(not(feature = "lzma"))]
+pub(crate) fn decompress_lzma(_bytes: &[u8]) -> Result<Output<'_>, Box<dyn Error>> {
+  Err(Box::<dyn Error>::from("unsupported SWF compression method `Lzma`: compile `swf-parser` with the `lzma` feature"))
 }

--- a/rs/src/streaming/movie.rs
+++ b/rs/src/streaming/movie.rs
@@ -11,12 +11,8 @@ pub fn parse_swf(input: &[u8]) -> NomResult<&[u8], ast::Movie> {
 
   let result = match signature.compression_method {
     ast::CompressionMethod::None => decompress::decompress_none(input),
-    #[cfg(feature="deflate")]
     ast::CompressionMethod::Deflate => decompress::decompress_zlib(input),
-    #[cfg(feature="lzma")]
     ast::CompressionMethod::Lzma => decompress::decompress_lzma(input),
-    #[allow(unreachable_patterns)]
-    method => panic!("Unsupported compression method: {:?}", method),
   };
   let (input, payload) = result.unwrap();
 

--- a/rs/src/streaming/parser/deflate.rs
+++ b/rs/src/streaming/parser/deflate.rs
@@ -1,7 +1,6 @@
 use crate::stream_buffer::StreamBuffer;
 use inflate::InflateStream;
 use swf_types::{Header as SwfHeader, SwfSignature, Tag};
-
 use super::{ParseTagsError, SimpleStream};
 
 /// State of the `Deflate` payload parser


### PR DESCRIPTION
Return a runtime error instead of a panic when failing to decompress the movie payload due to a disable feature.