### PR TITLE
[rs] Require Rust 1.60.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,12 @@
 
 ## Rust
 
-- **[Feature]** Add LZMA support to `streaming::movie::parse_swf`.
-- **[Change]** Compression support can be opted-out by disabling the corresponding features.
-
-# Typescript
-
-- **[Breaking change]** Update to `swf-types@0.14`.
-- **[Breaking change]** Compile to `.mjs`.
-- **[Fix]** Update dependencies.
-- **[Internal]** Use Yarn's Plug'n'Play linker.
+- **[Breaking change]** Require Rust `1.60.0`.
+- **[Feature]** You may opt out from compression support. Compression is now
+  provided by the enabled-by-default features `deflate` and `lzma`.
+- **[Feature]** Add support streaming support for movies using the `Deflate`
+  compression method.
+- **[Fix]** Update dependencies ([#147](https://github.com/open-flash/swf-types/issues/147)).
 
 # 0.13.0 (2021-07-23)
 

--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -80,9 +80,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "minimal-lexical"
@@ -138,12 +138,6 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b96a9549dc8d48f2c283938303c4b5a77aa29bfbc5b54b084fb1630408899a8f"
-
-[[package]]
-name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
@@ -156,18 +150,18 @@ checksum = "6518fc26bced4d53678a22d6e423e9d8716377def84545fe328236e3af070e7f"
 
 [[package]]
 name = "serde"
-version = "1.0.136"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
+checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.136"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
+checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
 dependencies = [
  "proc-macro2 1.0.37",
  "quote 1.0.17",
@@ -181,20 +175,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
 dependencies = [
  "itoa 1.0.1",
- "ryu 1.0.9",
+ "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_json_v8"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22de6b4971227e34df07cfa957decd3d40b0fcc4dde8c367779f98e4c08e3be0"
-dependencies = [
- "itoa 0.4.8",
- "ryu 0.2.8",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -228,37 +210,26 @@ dependencies = [
  "memchr",
  "nom",
  "serde",
- "serde_json_v8 0.1.1",
+ "serde_json_v8",
  "swf-fixed",
- "swf-types 0.13.0",
+ "swf-types",
  "test-generator",
 ]
 
 [[package]]
 name = "swf-parser-bin"
-version = "0.1.0"
+version = "0.14.0"
 dependencies = [
- "serde_json_v8 0.0.1",
+ "serde_json_v8",
  "swf-parser",
- "swf-types 0.10.0",
+ "swf-types",
 ]
 
 [[package]]
 name = "swf-types"
-version = "0.10.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c05702364986055179557b04f797fecbc0cd1ef12c07536edd254b085b3540"
-dependencies = [
- "hex",
- "serde",
- "swf-fixed",
-]
-
-[[package]]
-name = "swf-types"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb2031567696a349ba68352057217eeff2a84d8d3e5fa3c18f86ea73f868364e"
+checksum = "6504ca71457976a3b3f42174a5f2a03798a7c326276816b4037f482245c35d94"
 dependencies = [
  "hex",
  "serde",

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -9,7 +9,8 @@ repository = "https://github.com/open-flash/swf-parser"
 readme = "./README.md"
 keywords = ["parser", "swf", "flash"]
 license = "AGPL-3.0-or-later"
-edition = "2018"
+edition = "2021"
+rust-version = "1.60.0"
 
 [badges]
 travis-ci = { repository = "open-flash/swf-parser", branch = "master" }
@@ -18,28 +19,27 @@ travis-ci = { repository = "open-flash/swf-parser", branch = "master" }
 name = "swf_parser"
 path = "src/lib.rs"
 
-[features]
-default = ["deflate", "lzma"]
-deflate = ["inflate"]
-lzma = ["lzma-rs"]
-
 [dependencies]
 half = "1.8.2"
-memchr = "2.4.1"
-nom = "7.1.1"
-swf-fixed = "0.1.5"
-swf-types = { version = "0.13.0", default-features = false }
 inflate = { version = "0.4.5", optional = true }
 lzma-rs = { version = "0.2.0", optional = true }
+memchr = "2.5.0"
+nom = "7.1.1"
+swf-fixed = "0.1.5"
+swf-types = { version = "0.14.0", default-features = false }
 
 [dev-dependencies]
-serde = "1.0.136"
+serde = "1.0.137"
 serde_json_v8 = "0.1.1"
-swf-types = { version = "0.13.0", default-features = true }
+swf-types = { version = "0.14.0", features = ["serde"] }
 test-generator = "0.3.0"
 
-# [replace]
-# "swf-types:0.9.0" = { git="https://github.com/open-flash/swf-types.git", rev = "524f19adc098d83900e94bbe693887a63b50786d" }
+[features]
+default = ["deflate", "lzma"]
+# Enable support for SWF movies compressed with declate
+deflate = ["dep:inflate"]
+# Enable support for SWF movies compressed with LZMA
+lzma = ["dep:lzma-rs"]
 
 # When testing larger files, increasing `opt-level` provides a significant speed-up.
 # [profile.test]

--- a/rs/bin/Cargo.toml
+++ b/rs/bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swf-parser-bin"
-version = "0.1.0"
+version = "0.14.0"
 authors = ["Charles Samborski <demurgos@demurgos.net>"]
 description = "SWF parser"
 documentation = "https://github.com/open-flash/swf-parser"
@@ -9,13 +9,14 @@ repository = "https://github.com/open-flash/swf-parser"
 readme = "../README.md"
 keywords = ["parser", "swf", "flash"]
 license = "AGPL-3.0-or-later"
-edition = "2018"
+edition = "2021"
+rust-version = "1.60.0"
 
 [[bin]]
 name = "swf-parser"
 path = "src/main.rs"
 
 [dependencies]
-serde_json_v8 = "^0.0.1"
-swf-parser = { path = "../" }
-swf-types = "^0.10.0"
+serde_json_v8 = "^0.1.1"
+swf-parser = { path = "../." }
+swf-types = "^0.14.0"

--- a/rs/fuzz/Cargo.lock
+++ b/rs/fuzz/Cargo.lock
@@ -10,33 +10,9 @@ checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
 name = "arbitrary"
-version = "0.4.6"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0922a3e746b5a44e111e5603feb6704e5cc959116f66737f50bb5cbd264e9d87"
-
-[[package]]
-name = "arrayvec"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
-
-[[package]]
-name = "bitflags"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
-
-[[package]]
-name = "bitvec"
-version = "0.19.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8942c8d352ae1838c9dda0b0ca2ab657696ef2232a20147cf1b30ae1a9cb4321"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
+checksum = "c38b6b6b79f671c25e1a3e785b7b82d7562ffc9cd3efdc98627e5668a2472490"
 
 [[package]]
 name = "build_const"
@@ -57,12 +33,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef611cc68ff783f18535d77ddd080185275713d852c4f5cbb6122c462a7a825c"
 
 [[package]]
-name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-
-[[package]]
 name = "crc"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -72,16 +42,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "funty"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
-
-[[package]]
 name = "half"
-version = "1.7.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62aca2aba2d62b4a7f5b33f3712cb1b0692779a56fb510499d5c0aa594daeaf3"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "inflate"
@@ -93,26 +57,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "lexical-core"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db65c6da02e61f55dae90a0ae427b2a5f6b3e8db09f58d10efab23af92592616"
-dependencies = [
- "arrayvec",
- "bitflags",
- "cfg-if",
- "ryu",
- "static_assertions",
-]
-
-[[package]]
 name = "libfuzzer-sys"
-version = "0.3.4"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee8c42ab62f43795ed77a965ed07994c5584cdc94fd0ebf14b22ac1524077acc"
+checksum = "336244aaeab6a12df46480dc585802aa743a72d66b11937844c61bbca84c991d"
 dependencies = [
  "arbitrary",
  "cc",
+ "once_cell",
 ]
 
 [[package]]
@@ -127,46 +79,37 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.3.3"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "nom"
-version = "6.2.1"
+version = "7.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c5c51b9083a3c620fa67a2a635d1ce7d95b897e957d6b28ff9a5da960a103a6"
+checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
 dependencies = [
- "bitvec",
- "funty",
- "lexical-core",
  "memchr",
- "version_check",
+ "minimal-lexical",
 ]
 
 [[package]]
-name = "radium"
-version = "0.5.3"
+name = "once_cell"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
-
-[[package]]
-name = "ryu"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
 
 [[package]]
 name = "serde"
 version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96fe57af81d28386a513cbc6858332abc6117cfdb5999647c6444b8f43a370a5"
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "swf-fixed"
@@ -200,27 +143,9 @@ dependencies = [
 
 [[package]]
 name = "swf-types"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb2031567696a349ba68352057217eeff2a84d8d3e5fa3c18f86ea73f868364e"
+checksum = "6504ca71457976a3b3f42174a5f2a03798a7c326276816b4037f482245c35d94"
 dependencies = [
  "swf-fixed",
 ]
-
-[[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
-name = "version_check"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
-
-[[package]]
-name = "wyz"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"

--- a/rs/fuzz/Cargo.toml
+++ b/rs/fuzz/Cargo.toml
@@ -3,16 +3,16 @@ name = "swf-parser-fuzz"
 version = "0.0.0"
 authors = ["Automatically generated"]
 publish = false
-edition = "2018"
+edition = "2021"
 
 [package.metadata]
 cargo-fuzz = true
 
 [dependencies]
-libfuzzer-sys = "^0.3.4"
+libfuzzer-sys = "^0.4.3"
 
 [dependencies.swf-parser]
-path = ".."
+path = "../."
 
 # Prevent this from interfering with workspaces
 [workspace]

--- a/rs/src/streaming/decompress.rs
+++ b/rs/src/streaming/decompress.rs
@@ -9,17 +9,27 @@ pub(crate) fn decompress_none(bytes: &[u8]) -> Result<Output<'_>, Box<dyn Error>
   Ok((&[][..], bytes.into()))
 }
 
-#[cfg(feature="deflate")]
-pub(crate) fn decompress_zlib(bytes: &[u8]) ->Result<Output<'_>, Box<dyn Error>> {
+#[cfg(feature = "deflate")]
+pub(crate) fn decompress_zlib(bytes: &[u8]) -> Result<Output<'_>, Box<dyn Error>> {
   let out = inflate::inflate_bytes_zlib(bytes).map_err(|msg| {
     Box::<dyn Error>::from(msg)
   })?;
   Ok((&[][..], out.into()))
 }
 
-#[cfg(feature="lzma")]
+#[cfg(not(feature = "deflate"))]
+pub(crate) fn decompress_zlib(_bytes: &[u8]) -> Result<Output<'_>, Box<dyn Error>> {
+  Err(Box::<dyn Error>::from("unsupported SWF compression method `Deflate`: compile `swf-parser` with the `deflate` feature"))
+}
+
+#[cfg(feature = "lzma")]
 pub(crate) fn decompress_lzma(mut bytes: &[u8]) -> Result<Output<'_>, Box<dyn Error>> {
   let mut out = Vec::new();
   lzma_rs::lzma_decompress(&mut bytes, &mut out).map_err(Box::new)?;
   Ok((bytes, out.into()))
+}
+
+#[cfg(not(feature = "lzma"))]
+pub(crate) fn decompress_lzma(_bytes: &[u8]) -> Result<Output<'_>, Box<dyn Error>> {
+  Err(Box::<dyn Error>::from("unsupported SWF compression method `Lzma`: compile `swf-parser` with the `lzma` feature"))
 }

--- a/rs/src/streaming/movie.rs
+++ b/rs/src/streaming/movie.rs
@@ -11,12 +11,8 @@ pub fn parse_swf(input: &[u8]) -> NomResult<&[u8], ast::Movie> {
 
   let result = match signature.compression_method {
     ast::CompressionMethod::None => decompress::decompress_none(input),
-    #[cfg(feature="deflate")]
     ast::CompressionMethod::Deflate => decompress::decompress_zlib(input),
-    #[cfg(feature="lzma")]
     ast::CompressionMethod::Lzma => decompress::decompress_lzma(input),
-    #[allow(unreachable_patterns)]
-    method => panic!("Unsupported compression method: {:?}", method),
   };
   let (input, payload) = result.unwrap();
 

--- a/rs/src/streaming/parser/deflate.rs
+++ b/rs/src/streaming/parser/deflate.rs
@@ -1,7 +1,6 @@
 use crate::stream_buffer::StreamBuffer;
 use inflate::InflateStream;
 use swf_types::{Header as SwfHeader, SwfSignature, Tag};
-
 use super::{ParseTagsError, SimpleStream};
 
 /// State of the `Deflate` payload parser


### PR DESCRIPTION
Update dependencies, update to Rust 2021, use explicit feature syntax (requires Rust 1.60.0).