### PR TITLE
[all] Release v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Next
+# 0.14.0 (2022-05-08)
 
 - **[Breaking change]** Require Rust `1.60.0`.
 - **[Internal]** Migrate from Travis CI to GitHub Actions.

--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -202,7 +202,7 @@ dependencies = [
 
 [[package]]
 name = "swf-parser"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "half",
  "inflate",

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swf-parser"
-version = "0.13.0"
+version = "0.14.0"
 authors = ["Charles Samborski <demurgos@demurgos.net>"]
 description = "SWF parser"
 documentation = "https://docs.rs/swf-parser"

--- a/rs/fuzz/Cargo.lock
+++ b/rs/fuzz/Cargo.lock
@@ -122,7 +122,7 @@ dependencies = [
 
 [[package]]
 name = "swf-parser"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "half",
  "inflate",

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swf-parser",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "SWF parser",
   "licenses": [
     {


### PR DESCRIPTION
- **[Breaking change]** Require Rust `1.60.0`.
- **[Internal]** Migrate from Travis CI to GitHub Actions.

## Rust

- **[Feature]** You may opt out from compression support. Compression is now
  provided by the enabled-by-default features `deflate` and `lzma`.
- **[Feature]** Add support streaming support for movies using the `Deflate`
  compression method.
- **[Fix]** Update dependencies ([#147](https://github.com/open-flash/swf-types/issues/147)).

# Typescript

- **[Breaking change]** Compile to `.mjs`.
- **[Fix]** Update dependencies.
- **[Internal]** Use Yarn's Plug'n'Play linker.